### PR TITLE
Add optional ingress style switch to generic chart

### DIFF
--- a/charts/generic/Chart.yaml
+++ b/charts/generic/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: generic
 description: A generic helm chart that handles a bunch of common application deploy cases
 type: application
-version: 1.9.0
+version: 1.10.0

--- a/charts/generic/templates/ingress.yaml
+++ b/charts/generic/templates/ingress.yaml
@@ -32,8 +32,11 @@ spec:
       {{- range .Values.ingress.hosts }}
         - {{ .host | quote }}
       {{- end }}
+      {{- if .Values.ingress.tlsSecretEnabled }}
       secretName: "{{ .Values.ingress.tlsSecretName | default (printf "%s-tls" .Release.Name) }}"
+      {{- end }}
   {{- end }}
+  {{- if eq $.Values.ingress.ruleType "rules" }}
   rules:
     {{- range .Values.ingress.hosts }}
     - host: {{ .host | quote }}
@@ -56,4 +59,11 @@ spec:
               {{- end }}
           {{- end }}
     {{- end }}
+  {{- else if eq $.Values.ingress.ruleType "defaultBackend" }}
+  defaultBackend:
+    service:
+      name: {{ $fullName }}
+      port:
+        number: {{ $svcPort }}
+  {{- end }}
 {{- end }}

--- a/charts/generic/values.yaml
+++ b/charts/generic/values.yaml
@@ -121,6 +121,11 @@ ingress:
   # Uncomment the following to use a pre-generated TLS Secret
   # tlsSecretName: ""
 
+  # Set to false if TLS is enabled, but you're using an ingress class that doesn't support TLS cert secrets
+  tlsSecretEnabled: true
+  # Switch between different Ingress rule styles. Can be one of "rules", or "defaultBackend"
+  ruleType: "rules"
+
 networkPolicy:
   enabled: false
   policyTypes: []


### PR DESCRIPTION
This adds the ability to support other ingressClasses that use the Ingress resource differently than most common ingress controllers like nginx.