### PR TITLE
Reference the root when looping external secret files

### DIFF
--- a/charts/generic/Chart.yaml
+++ b/charts/generic/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: generic
 description: A generic helm chart that handles a bunch of common application deploy cases
 type: application
-version: 1.15.0
+version: 1.15.1

--- a/charts/generic/templates/deployment.yaml
+++ b/charts/generic/templates/deployment.yaml
@@ -116,7 +116,7 @@ spec:
               mountPath: {{ .mountPath }}/{{ .filename }}
               subPath: {{ .filename }}
             {{- end }}
-            {{- range $ext := .Values.externalSecretFiles }}
+            {{- range $ext := $.Values.externalSecretFiles }}
             {{- range $file := $ext.files }}
             - name: ext-s-{{ $ext.secretName }}
               mountPath: {{ $file.mountPath }}/{{ $file.filename }}
@@ -203,7 +203,7 @@ spec:
               mountPath: {{ .mountPath }}/{{ .filename }}
               subPath: {{ .filename }}
             {{- end }}
-            {{- range $ext := .Values.externalSecretFiles }}
+            {{- range $ext := $.Values.externalSecretFiles }}
             {{- range $file := $ext.files }}
             - name: ext-s-{{ $ext.secretName }}
               mountPath: {{ $file.mountPath }}/{{ $file.filename }}
@@ -290,7 +290,7 @@ spec:
               mountPath: {{ .mountPath }}/{{ .filename }}
               subPath: {{ .filename }}
             {{- end }}
-            {{- range $ext := .Values.externalSecretFiles }}
+            {{- range $ext := $.Values.externalSecretFiles }}
             {{- range $file := $ext.files }}
             - name: ext-s-{{ $ext.secretName }}
               mountPath: {{ $file.mountPath }}/{{ $file.filename }}


### PR DESCRIPTION
Fixes an issue when using sidecars or init containers, since we're already in a loop there and .Values doesn't refer to the root anymore