### PR TITLE
Generic Chart: Granular Secret Environment Control

### DIFF
--- a/charts/generic/Chart.yaml
+++ b/charts/generic/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: generic
 description: A generic helm chart that handles a bunch of common application deploy cases
 type: application
-version: 1.16.0
+version: 1.17.0

--- a/charts/generic/templates/deployment.yaml
+++ b/charts/generic/templates/deployment.yaml
@@ -154,6 +154,11 @@ spec:
             {{- end }}
           {{- end }}
           envFrom:
+            {{- if .Values.deployment.secretEnvironment }}
+            - secretRef:
+                name: "{{ .Release.Name }}-main-env"
+                optional: false
+            {{- end }}
             - secretRef:
                 name: "{{ .Release.Name }}-env"
                 optional: false
@@ -241,6 +246,11 @@ spec:
             {{- end }}
           {{- end }}
           envFrom:
+            {{- if .secretEnvironment }}
+            - secretRef:
+                name: "{{ $.Release.Name }}-{{ $sidecarName }}-env"
+                optional: false
+            {{- end }}
             - secretRef:
                 name: "{{ $.Release.Name }}-env"
                 optional: false

--- a/charts/generic/templates/secret-environment-main.yaml
+++ b/charts/generic/templates/secret-environment-main.yaml
@@ -1,0 +1,10 @@
+{{- if .Values.deployment.secretEnvironment }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: "{{ .Release.Name }}-main-env"
+  labels:
+    {{- include "generic.labels" . | nindent 4 }}
+stringData:
+  {{- toYaml .Values.deployment.secretEnvironment | trim | nindent 2 }}
+{{- end }}

--- a/charts/generic/templates/secret-environment-sidecar.yaml
+++ b/charts/generic/templates/secret-environment-sidecar.yaml
@@ -1,0 +1,13 @@
+{{- range .Values.sidecars }}
+{{- if .secretEnvironment }}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: "{{ $.Release.Name }}-{{ .name }}-env"
+  labels:
+    {{- include "generic.labels" $ | nindent 4 }}
+stringData:
+  {{- toYaml .secretEnvironment | trim | nindent 2 }}
+{{- end }}
+{{- end }}

--- a/charts/generic/values.yaml
+++ b/charts/generic/values.yaml
@@ -33,6 +33,9 @@ sidecars: []
 #      pullPolicy: IfNotPresent
 #      tag: latest
 #    environment: {}
+#      MY_KEY: "My Value"
+#    secretEnvironment: {}
+#      MY_KEY: "My Value"
 
 imagePullSecrets: []
 nameOverride: ""
@@ -80,6 +83,9 @@ deployment:
 #      protocol: TCP
   # Environment variables to add directly to the deployment configuration (as opposed to via the secret or configmap)
   environment: {}
+  #  MY_KEY: "My Value"
+  # Secret environment variables to add ONLY to the main container (will not be shared with sidecars/init containers)
+  secretEnvironment: {}
   #  MY_KEY: "My Value"
   livenessProbe: {}
 #    httpGet:
@@ -177,7 +183,7 @@ serviceMonitor:
   relabelings: []
   metricRelabelings: []
 
-# Creates a secret with the following values, and mounts as env into the main deployment container
+# Creates a secret with the following values, and mounts as env into all the containers
 secretEnvironment: {}
 #  MY_KEY: "My Value"
 
@@ -185,7 +191,7 @@ secretEnvironment: {}
 externalSecretEnvironment: []
 #  - name: "secret-name"
 
-# Creates a secret with the following values, and mounts as a file into the main deployment container
+# Creates a secret with the following values, and mounts as a file into all the containers
 secretFile:
   mountPath: "/etc/secrets"
   values: {}


### PR DESCRIPTION
Adds support for secret-based environment vars for specific containers instead of having to use global/shared secret env vars. Retains support for the global (all container) secret env setting, while also allowing a secret to be created for the main container and each sidecar container, individually.