### PR TITLE
Allow setting a volumeName / selector on a PVC if using something tha…

### DIFF
--- a/charts/generic/Chart.yaml
+++ b/charts/generic/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: generic
 description: A generic helm chart that handles a bunch of common application deploy cases
 type: application
-version: 1.26.0
+version: 1.27.0

--- a/charts/generic/templates/volumes.yaml
+++ b/charts/generic/templates/volumes.yaml
@@ -41,5 +41,12 @@ spec:
     requests:
       storage: {{ .size }}
   storageClassName: {{ .storageClassName }}
+  {{- if .volumeName }}
+  volumeName: {{ .volumeName }}
+  {{- end }}
+  {{- if .selector }}
+  selector:
+    {{- toYaml .selector | nindent 4 }}
+  {{- end }}
 {{- end }}
 {{- end }}

--- a/charts/generic/values.yaml
+++ b/charts/generic/values.yaml
@@ -314,6 +314,11 @@ volumes: []
 #      - ReadWriteOnce
 #    storageClassName: ceph-nvme
 #    volumeMode: Filesystem|Block
+#    volumeName: my-persistent-volume # Bind directly to this PV if set (vs letting a storage class provision a PV)
+#    selector: # Selector to match a PV if volumeName is not set (vs letting a storage class provision a PV)
+#      matchLabels:
+#        app: my-app
+#        environment: production
 
 # Persistent Volumes created/managed external to this helm release
 externalVolumes: []


### PR DESCRIPTION
…t wont dynamically provision

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces optional PVC binding controls and bumps chart version.
> 
> - Adds optional `volumeName` and `selector` to PVCs in `templates/volumes.yaml` to allow direct PV binding or label-based selection
> - Updates `values.yaml` examples to document `volumeName` and `selector` under `volumes`
> - Bumps chart version to `1.27.0`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a24d4df148b5fff7fbd0c165f08707f87c11e30e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->