### PR TITLE
Storage class quote + add PV support (optional)

### DIFF
--- a/.github/workflows/install-charts.yaml
+++ b/.github/workflows/install-charts.yaml
@@ -105,6 +105,41 @@ jobs:
             exit 1
           fi
 
+      - name: Test PersistentVolumes - verify no PV created by default
+        run: |
+          helm template test ./charts/generic -f ./charts/generic/test-values-pv-default.yaml > /tmp/pv-default-output.yaml
+          if grep -q "kind: PersistentVolume" /tmp/pv-default-output.yaml; then
+            echo "✗ Unexpected PersistentVolume found in default values output"
+            exit 1
+          else
+            echo "✓ No PersistentVolume created by default (correct)"
+          fi
+
+      - name: Test PersistentVolumes - verify PVs can be created
+        run: |
+          helm template test ./charts/generic -f ./charts/generic/test-values-pv-created.yaml > /tmp/pv-created-output.yaml
+          PV_COUNT=$(grep -c "kind: PersistentVolume" /tmp/pv-created-output.yaml || echo "0")
+          if [ "$PV_COUNT" -eq 2 ]; then
+            echo "✓ Correctly created 2 PersistentVolumes"
+          else
+            echo "✗ Expected 2 PersistentVolumes, found $PV_COUNT"
+            exit 1
+          fi
+          # Verify PV names
+          if grep -q "name: test-pv-1" /tmp/pv-created-output.yaml && grep -q "name: test-pv-2" /tmp/pv-created-output.yaml; then
+            echo "✓ Both PVs have correct names"
+          else
+            echo "✗ PV names not found as expected"
+            exit 1
+          fi
+          # Verify PV specs
+          if grep -q "storage: 10Gi" /tmp/pv-created-output.yaml && grep -q "storage: 5Gi" /tmp/pv-created-output.yaml; then
+            echo "✓ PVs have correct storage sizes"
+          else
+            echo "✗ PV storage sizes not found as expected"
+            exit 1
+          fi
+
       - name: Install generic-stateful chart
         uses: Chia-Network/actions/helm/deploy@main
         with:

--- a/charts/generic/Chart.yaml
+++ b/charts/generic/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: generic
 description: A generic helm chart that handles a bunch of common application deploy cases
 type: application
-version: 1.27.1
+version: 1.28.0

--- a/charts/generic/Chart.yaml
+++ b/charts/generic/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: generic
 description: A generic helm chart that handles a bunch of common application deploy cases
 type: application
-version: 1.27.0
+version: 1.27.1

--- a/charts/generic/templates/persistentVolumes.yaml
+++ b/charts/generic/templates/persistentVolumes.yaml
@@ -1,0 +1,23 @@
+{{- if .Values.persistentVolumes }}
+{{- range .Values.persistentVolumes }}
+---
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: {{ .name }}
+  {{- if .labels }}
+  labels:
+    {{- toYaml .labels | nindent 4 }}
+  {{- end }}
+spec:
+  capacity:
+    storage: {{ .size }}
+  accessModes:
+    {{- toYaml .accessModes | nindent 4 }}
+  persistentVolumeReclaimPolicy: {{ .persistentVolumeReclaimPolicy }}
+  storageClassName: {{ .storageClassName | quote }}
+  {{- if .extraYaml }}
+  {{- toYaml .extraYaml | nindent 2 }}
+  {{- end }}
+{{- end }}
+{{- end }}

--- a/charts/generic/templates/volumes.yaml
+++ b/charts/generic/templates/volumes.yaml
@@ -40,7 +40,7 @@ spec:
   resources:
     requests:
       storage: {{ .size }}
-  storageClassName: {{ .storageClassName }}
+  storageClassName: {{ .storageClassName | quote }}
   {{- if .volumeName }}
   volumeName: {{ .volumeName }}
   {{- end }}

--- a/charts/generic/test-values-pv-created.yaml
+++ b/charts/generic/test-values-pv-created.yaml
@@ -1,0 +1,32 @@
+# Test values to verify PersistentVolumes can be created
+mode: deployment
+replicaCount: 1
+image:
+  repository: nginx
+  tag: latest
+deployment:
+  containerPort: 80
+  containerPortName: http
+persistentVolumes:
+  - name: test-pv-1
+    labels:
+      app: test-app
+      environment: test
+    size: 10Gi
+    accessModes:
+      - ReadWriteOnce
+    persistentVolumeReclaimPolicy: Retain
+    storageClassName: local-storage
+    extraYaml:
+      hostPath:
+        path: /data/test-volume
+  - name: test-pv-2
+    size: 5Gi
+    accessModes:
+      - ReadWriteMany
+    persistentVolumeReclaimPolicy: Delete
+    storageClassName: nfs-storage
+    extraYaml:
+      nfs:
+        server: 1.2.3.4
+        path: /exports/test

--- a/charts/generic/test-values-pv-default.yaml
+++ b/charts/generic/test-values-pv-default.yaml
@@ -1,0 +1,9 @@
+# Minimal values to test that PersistentVolumes are NOT created by default
+mode: deployment
+replicaCount: 1
+image:
+  repository: nginx
+  tag: latest
+deployment:
+  containerPort: 80
+  containerPortName: http

--- a/charts/generic/values.yaml
+++ b/charts/generic/values.yaml
@@ -320,6 +320,24 @@ volumes: []
 #        app: my-app
 #        environment: production
 
+# Persistent Volumes - creates PV resources (optional, usually expected to be managed by a storage class)
+persistentVolumes: []
+#  - name: my-persistent-volume
+#    labels:
+#      app: my-app
+#      environment: production
+#    size: 10Gi
+#    accessModes:
+#      - ReadWriteOnce
+#    persistentVolumeReclaimPolicy: Retain
+#    storageClassName: local-storage
+#    extraYaml: # Extra YAML to add directly to the PV spec
+#      mountOptions:
+#        - vers=4.1
+#      nfs:
+#        server: 1.2.3.4
+#        path: /path/on/nfs
+
 # Persistent Volumes created/managed external to this helm release
 externalVolumes: []
 #  - name: example-volume


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Introduces optional PersistentVolume support and minor template fix in the generic chart.
> 
> - Adds `templates/persistentVolumes.yaml` to render PVs when `values.persistentVolumes` is provided; includes labels, size, accessModes, reclaimPolicy, storageClassName, and `extraYaml`
> - Quotes `storageClassName` in `templates/volumes.yaml` PVC spec
> - Extends CI workflow to verify no PVs by default and correct PV rendering when configured; adds `test-values-pv-default.yaml` and `test-values-pv-created.yaml`
> - Bumps `charts/generic` version to `1.28.0`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b3935f903531339ff7f7964c0547927bc027dcc2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->