### PR TITLE
Add job and cronjob modes to generic chart

### DIFF
--- a/.github/workflows/install-charts.yaml
+++ b/.github/workflows/install-charts.yaml
@@ -140,6 +140,158 @@ jobs:
             exit 1
           fi
 
+      - name: Test job mode - verify template structure
+        run: |
+          helm template test ./charts/generic -f ./charts/generic/test-values-job.yaml > /tmp/job-output.yaml
+          # Must produce a Job, not a Deployment or StatefulSet
+          if grep -q "kind: Job" /tmp/job-output.yaml; then
+            echo "✓ Job resource found"
+          else
+            echo "✗ Job resource not found"
+            exit 1
+          fi
+          if kubectl get deployment generic-job-mode-test -n generic-job-mode 2>/dev/null || grep -q "kind: Deployment" /tmp/job-output.yaml; then
+            echo "✗ Unexpected Deployment found in job mode output"
+            exit 1
+          else
+            echo "✓ No Deployment in job mode output (correct)"
+          fi
+          # Must have Helm hook annotations for re-run-on-upgrade behavior
+          if grep -q "helm.sh/hook" /tmp/job-output.yaml; then
+            echo "✓ Helm hook annotations present"
+          else
+            echo "✗ Missing helm hook annotations on Job"
+            exit 1
+          fi
+          if grep -q "before-hook-creation" /tmp/job-output.yaml; then
+            echo "✓ before-hook-creation delete policy present"
+          else
+            echo "✗ Missing before-hook-creation delete policy"
+            exit 1
+          fi
+
+      - name: Test job mode - install
+        uses: Chia-Network/actions/helm/deploy@main
+        with:
+          namespace: "generic-job-mode"
+          app_name: "generic-job-mode-test"
+          helm_chart: "./charts/generic"
+          helm_values: "./charts/generic/test-values-job.yaml"
+
+      - name: Test job mode - verify Job ran after install
+        run: |
+          # Wait for the hook Job to complete
+          kubectl wait --for=condition=complete job/generic-job-mode-test \
+            -n generic-job-mode --timeout=60s
+          if [ $? -eq 0 ]; then
+            echo "✓ Job completed successfully after helm install"
+          else
+            echo "✗ Job did not complete within timeout"
+            kubectl describe job generic-job-mode-test -n generic-job-mode
+            exit 1
+          fi
+          # Verify no Deployment was created
+          if kubectl get deployment generic-job-mode-test -n generic-job-mode 2>/dev/null; then
+            echo "✗ Unexpected Deployment found (should only be a Job)"
+            exit 1
+          else
+            echo "✓ No Deployment found (correct)"
+          fi
+
+      - name: Test job mode - upgrade re-runs the job
+        uses: Chia-Network/actions/helm/deploy@main
+        with:
+          namespace: "generic-job-mode"
+          app_name: "generic-job-mode-test"
+          helm_chart: "./charts/generic"
+          helm_values: "./charts/generic/test-values-job.yaml"
+
+      - name: Test job mode - verify Job ran again after upgrade
+        run: |
+          kubectl wait --for=condition=complete job/generic-job-mode-test \
+            -n generic-job-mode --timeout=60s
+          if [ $? -eq 0 ]; then
+            echo "✓ Job completed successfully after helm upgrade (old job was deleted and re-created)"
+          else
+            echo "✗ Job did not complete within timeout after upgrade"
+            kubectl describe job generic-job-mode-test -n generic-job-mode
+            exit 1
+          fi
+
+      - name: Test cronjob mode - verify template structure
+        run: |
+          helm template test ./charts/generic -f ./charts/generic/test-values-cronjob.yaml > /tmp/cronjob-output.yaml
+          # Must produce a CronJob, not a Deployment or StatefulSet
+          if grep -q "kind: CronJob" /tmp/cronjob-output.yaml; then
+            echo "✓ CronJob resource found"
+          else
+            echo "✗ CronJob resource not found"
+            exit 1
+          fi
+          if grep -q "kind: Deployment" /tmp/cronjob-output.yaml; then
+            echo "✗ Unexpected Deployment found in cronjob mode output"
+            exit 1
+          else
+            echo "✓ No Deployment in cronjob mode output (correct)"
+          fi
+          # Must not have Helm hook annotations (CronJob is a normal release resource)
+          if grep -q "helm.sh/hook" /tmp/cronjob-output.yaml; then
+            echo "✗ Unexpected Helm hook annotations on CronJob (should only be on Job mode)"
+            exit 1
+          else
+            echo "✓ No Helm hook annotations on CronJob (correct)"
+          fi
+          # Verify schedule is rendered
+          if grep -q 'schedule: "\*/5 \* \* \* \*"' /tmp/cronjob-output.yaml; then
+            echo "✓ Schedule rendered correctly"
+          else
+            echo "✗ Schedule not found in CronJob output"
+            exit 1
+          fi
+
+      - name: Test cronjob mode - install
+        uses: Chia-Network/actions/helm/deploy@main
+        with:
+          namespace: "generic-cronjob-mode"
+          app_name: "generic-cronjob-mode-test"
+          helm_chart: "./charts/generic"
+          helm_values: "./charts/generic/test-values-cronjob.yaml"
+
+      - name: Test cronjob mode - verify CronJob created
+        run: |
+          kubectl get cronjob generic-cronjob-mode-test -n generic-cronjob-mode
+          if [ $? -eq 0 ]; then
+            echo "✓ CronJob 'generic-cronjob-mode-test' exists in namespace 'generic-cronjob-mode'"
+          else
+            echo "✗ CronJob not found"
+            exit 1
+          fi
+          # Verify no Deployment was created
+          if kubectl get deployment generic-cronjob-mode-test -n generic-cronjob-mode 2>/dev/null; then
+            echo "✗ Unexpected Deployment found (should only be a CronJob)"
+            exit 1
+          else
+            echo "✓ No Deployment found (correct)"
+          fi
+
+      - name: Test cronjob mode - missing schedule should fail
+        run: |
+          set +e
+          helm template test ./charts/generic --set mode=cronjob 2>&1 | tee /tmp/cronjob-no-schedule.txt
+          EXIT_CODE=${PIPESTATUS[0]}
+          set -e
+          if [ $EXIT_CODE -eq 0 ]; then
+            echo "✗ Expected validation failure for cronjob without schedule, but helm template succeeded"
+            exit 1
+          fi
+          if grep -q "job.schedule is required" /tmp/cronjob-no-schedule.txt; then
+            echo "✓ Validation correctly failed with expected error message"
+          else
+            echo "✗ Validation failed but with unexpected error message"
+            cat /tmp/cronjob-no-schedule.txt
+            exit 1
+          fi
+
       - name: Install generic-stateful chart
         uses: Chia-Network/actions/helm/deploy@main
         with:

--- a/.github/workflows/install-charts.yaml
+++ b/.github/workflows/install-charts.yaml
@@ -181,9 +181,12 @@ jobs:
       - name: Test job mode - verify Job ran after install
         run: |
           # Wait for the hook Job to complete
+          set +e
           kubectl wait --for=condition=complete job/generic-job-mode-test \
             -n generic-job-mode --timeout=60s
-          if [ $? -eq 0 ]; then
+          JOB_EXIT=$?
+          set -e
+          if [ $JOB_EXIT -eq 0 ]; then
             echo "✓ Job completed successfully after helm install"
           else
             echo "✗ Job did not complete within timeout"
@@ -208,9 +211,12 @@ jobs:
 
       - name: Test job mode - verify Job ran again after upgrade
         run: |
+          set +e
           kubectl wait --for=condition=complete job/generic-job-mode-test \
             -n generic-job-mode --timeout=60s
-          if [ $? -eq 0 ]; then
+          JOB_EXIT=$?
+          set -e
+          if [ $JOB_EXIT -eq 0 ]; then
             echo "✓ Job completed successfully after helm upgrade (old job was deleted and re-created)"
           else
             echo "✗ Job did not complete within timeout after upgrade"

--- a/charts/generic/Chart.yaml
+++ b/charts/generic/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: generic
 description: A generic helm chart that handles a bunch of common application deploy cases
 type: application
-version: 1.28.0
+version: 1.29.0

--- a/charts/generic/templates/job.yaml
+++ b/charts/generic/templates/job.yaml
@@ -155,6 +155,15 @@ initContainers:
         subPath: {{ $file.filename }}
       {{- end }}
       {{- end }}
+      {{- range $.Values.externalVolumes }}
+      - name: {{ .name }}
+        mountPath: {{ .mountPath }}
+        readOnly: {{ .readOnly }}
+      {{- end }}
+      {{- range $.Values.hostVolumes }}
+      - name: {{ .name }}
+        mountPath: {{ .mountPath }}
+      {{- end }}
 {{- end }}
 {{- end }}
 containers:
@@ -225,6 +234,15 @@ containers:
         mountPath: {{ $file.mountPath }}/{{ $file.filename }}
         subPath: {{ $file.filename }}
       {{- end }}
+      {{- end }}
+      {{- range .Values.externalVolumes }}
+      - name: {{ .name }}
+        mountPath: {{ .mountPath }}
+        readOnly: {{ .readOnly }}
+      {{- end }}
+      {{- range .Values.hostVolumes }}
+      - name: {{ .name }}
+        mountPath: {{ .mountPath }}
       {{- end }}
     resources:
       {{- toYaml .Values.resources | nindent 6 }}

--- a/charts/generic/templates/job.yaml
+++ b/charts/generic/templates/job.yaml
@@ -1,0 +1,294 @@
+{{- if or (eq .Values.mode "job") (eq .Values.mode "cronjob") -}}
+{{- $fullName := include "generic.fullname" . -}}
+{{- $isJob := eq .Values.mode "job" -}}
+{{- if and (not $isJob) (not .Values.job.schedule) -}}
+{{- fail "job.schedule is required when mode is \"cronjob\" (e.g. job.schedule: \"0 2 * * *\")" -}}
+{{- end -}}
+apiVersion: batch/v1
+kind: {{ if $isJob }}Job{{ else }}CronJob{{ end }}
+metadata:
+  name: {{ $fullName }}
+  labels:
+    {{- include "generic.labels" . | nindent 4 }}
+  {{- if $isJob }}
+  annotations:
+    # These hooks cause the Job to be deleted and re-created on every helm install/upgrade,
+    # so each deploy triggers a fresh run without needing to uninstall and reinstall.
+    "helm.sh/hook": post-install,post-upgrade
+    "helm.sh/hook-delete-policy": before-hook-creation
+    "helm.sh/hook-weight": "0"
+  {{- end }}
+spec:
+  {{- if $isJob }}
+  backoffLimit: {{ .Values.job.backoffLimit }}
+  {{- if .Values.job.activeDeadlineSeconds }}
+  activeDeadlineSeconds: {{ .Values.job.activeDeadlineSeconds }}
+  {{- end }}
+  {{- if .Values.job.ttlSecondsAfterFinished }}
+  ttlSecondsAfterFinished: {{ .Values.job.ttlSecondsAfterFinished }}
+  {{- end }}
+  completions: {{ .Values.job.completions }}
+  parallelism: {{ .Values.job.parallelism }}
+  template:
+    metadata:
+      annotations:
+      {{- with .Values.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      labels:
+        {{- include "generic.selectorLabels" . | nindent 8 }}
+    spec:
+      {{- include "generic.jobPodSpec" . | nindent 6 }}
+  {{- else }}
+  schedule: {{ .Values.job.schedule | quote }}
+  concurrencyPolicy: {{ .Values.job.concurrencyPolicy }}
+  successfulJobsHistoryLimit: {{ .Values.job.successfulJobsHistoryLimit }}
+  failedJobsHistoryLimit: {{ .Values.job.failedJobsHistoryLimit }}
+  suspend: {{ .Values.job.suspend }}
+  jobTemplate:
+    metadata:
+      labels:
+        {{- include "generic.labels" . | nindent 8 }}
+    spec:
+      backoffLimit: {{ .Values.job.backoffLimit }}
+      {{- if .Values.job.activeDeadlineSeconds }}
+      activeDeadlineSeconds: {{ .Values.job.activeDeadlineSeconds }}
+      {{- end }}
+      {{- if .Values.job.ttlSecondsAfterFinished }}
+      ttlSecondsAfterFinished: {{ .Values.job.ttlSecondsAfterFinished }}
+      {{- end }}
+      completions: {{ .Values.job.completions }}
+      parallelism: {{ .Values.job.parallelism }}
+      template:
+        metadata:
+          annotations:
+          {{- with .Values.podAnnotations }}
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          labels:
+            {{- include "generic.selectorLabels" . | nindent 12 }}
+        spec:
+          {{- include "generic.jobPodSpec" . | nindent 10 }}
+  {{- end }}
+{{- end }}
+
+{{/*
+Shared pod spec for job and cronjob modes.
+Excludes ports, probes, lifecycle hooks, sidecars, HPA, strategy, and replicas.
+*/}}
+{{- define "generic.jobPodSpec" -}}
+restartPolicy: {{ .Values.job.restartPolicy }}
+{{- with .Values.imagePullSecrets }}
+imagePullSecrets:
+  {{- toYaml . | nindent 2 }}
+{{- end }}
+serviceAccountName: {{ include "generic.serviceAccountName" . }}
+securityContext:
+  {{- toYaml .Values.podSecurityContext | nindent 2 }}
+{{- with .Values.initContainers }}
+initContainers:
+{{- range $.Values.initContainers }}
+  - name: {{ .name }}
+    image: {{ .image }}
+    imagePullPolicy: {{ default "IfNotPresent" .imagePullPolicy }}
+    {{- if .command }}
+    command:
+      {{- range .command }}
+      - {{ . | quote }}
+      {{- end }}
+    {{- end }}
+    {{- if .args }}
+    args:
+      {{- range .args }}
+      - {{ . | quote }}
+      {{- end }}
+    {{- end }}
+    securityContext:
+      {{- toYaml $.Values.securityContext | nindent 6 }}
+    {{- with $.Values.deployment.environment }}
+    env:
+      {{- range $key, $value := . }}
+      - name: "{{ $key }}"
+        value: "{{ $value }}"
+      {{- end }}
+    {{- end }}
+    envFrom:
+      - secretRef:
+          name: "{{ $.Release.Name }}-env"
+          optional: false
+      {{- range $.Values.externalSecretEnvironment }}
+      - secretRef:
+          name: "{{ .name }}"
+      {{- end }}
+      - configMapRef:
+          name: "{{ $.Release.Name }}-env"
+      {{- range $.Values.externalConfigmapEnvironment }}
+      - configMapRef:
+          name: "{{ .name }}"
+      {{- end }}
+    volumeMounts:
+      {{- range $.Values.sharedEmptyDirs }}
+      - name: {{ .name }}
+        mountPath: {{ .mountPath }}
+      {{- end }}
+      - name: secret-file
+        mountPath: {{ $.Values.secretFile.mountPath }}
+        {{- if $.Values.secretFile.subPath }}
+        subPath: {{ $.Values.secretFile.subPath }}
+        {{- end }}
+      - name: configmap-file
+        mountPath: {{ $.Values.configmapFile.mountPath }}
+      {{- range $.Values.configmapFiles }}
+      - name: configmap-files
+        mountPath: {{ .mountPath }}/{{ .filename }}
+        subPath: {{ .filename }}
+      {{- end }}
+      {{- range $.Values.secretFiles }}
+      - name: secret-files
+        mountPath: {{ .mountPath }}/{{ .filename }}
+        subPath: {{ .filename }}
+      {{- end }}
+      {{- range $ext := $.Values.externalSecretFiles }}
+      {{- range $file := $ext.files }}
+      - name: ext-s-{{ $ext.secretName }}
+        mountPath: {{ $file.mountPath }}/{{ $file.filename }}
+        subPath: {{ $file.filename }}
+      {{- end }}
+      {{- end }}
+{{- end }}
+{{- end }}
+containers:
+  - name: {{ .Chart.Name }}
+    securityContext:
+      {{- toYaml .Values.securityContext | nindent 6 }}
+    image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+    imagePullPolicy: {{ .Values.image.pullPolicy }}
+    {{- if .Values.deployment.command }}
+    command:
+      {{- toYaml .Values.deployment.command | nindent 6 }}
+    {{- end }}
+    {{- if .Values.deployment.args }}
+    args:
+      {{- toYaml .Values.deployment.args | nindent 6 }}
+    {{- end }}
+    {{- with .Values.deployment.environment }}
+    env:
+      {{- range $key, $value := . }}
+      - name: "{{ $key }}"
+        value: "{{ $value }}"
+      {{- end }}
+    {{- end }}
+    envFrom:
+      {{- if .Values.deployment.secretEnvironment }}
+      - secretRef:
+          name: "{{ .Release.Name }}-main-env"
+          optional: false
+      {{- end }}
+      - secretRef:
+          name: "{{ .Release.Name }}-env"
+          optional: false
+      {{- range .Values.externalSecretEnvironment }}
+      - secretRef:
+          name: "{{ .name }}"
+      {{- end }}
+      - configMapRef:
+          name: "{{ .Release.Name }}-env"
+      {{- range .Values.externalConfigmapEnvironment }}
+      - configMapRef:
+          name: "{{ .name }}"
+      {{- end }}
+    volumeMounts:
+      {{- range .Values.sharedEmptyDirs }}
+      - name: {{ .name }}
+        mountPath: {{ .mountPath }}
+      {{- end }}
+      - name: secret-file
+        mountPath: {{ .Values.secretFile.mountPath }}
+        {{- if .Values.secretFile.subPath }}
+        subPath: {{ .Values.secretFile.subPath }}
+        {{- end }}
+      - name: configmap-file
+        mountPath: {{ .Values.configmapFile.mountPath }}
+      {{- range .Values.configmapFiles }}
+      - name: configmap-files
+        mountPath: {{ .mountPath }}/{{ .filename }}
+        subPath: {{ .filename }}
+      {{- end }}
+      {{- range .Values.secretFiles }}
+      - name: secret-files
+        mountPath: {{ .mountPath }}/{{ .filename }}
+        subPath: {{ .filename }}
+      {{- end }}
+      {{- range $ext := .Values.externalSecretFiles }}
+      {{- range $file := $ext.files }}
+      - name: ext-s-{{ $ext.secretName }}
+        mountPath: {{ $file.mountPath }}/{{ $file.filename }}
+        subPath: {{ $file.filename }}
+      {{- end }}
+      {{- end }}
+    resources:
+      {{- toYaml .Values.resources | nindent 6 }}
+volumes:
+  {{- range .Values.sharedEmptyDirs }}
+  - name: {{ .name }}
+    emptyDir: {}
+  {{- end }}
+  - name: secret-file
+    secret:
+      secretName: "{{ .Release.Name }}-file"
+  - name: configmap-file
+    configMap:
+      name: "{{ .Release.Name }}-file"
+  - name: configmap-files
+    configMap:
+      name: "{{ .Release.Name }}-files"
+      {{- if ne (len .Values.configmapFiles) 0 }}
+      items:
+      {{- range .Values.configmapFiles }}
+        - key: {{ .filename }}
+          path: {{ .filename }}
+      {{- end }}
+      {{- end }}
+  - name: secret-files
+    secret:
+      secretName: "{{ .Release.Name }}-files"
+      {{- if ne (len .Values.secretFiles) 0 }}
+      items:
+      {{- range .Values.secretFiles }}
+        - key: {{ .filename }}
+          path: {{ .filename }}
+      {{- end }}
+      {{- end }}
+  {{- range .Values.externalSecretFiles }}
+  - name: ext-s-{{ .secretName }}
+    secret:
+      secretName: {{ .secretName }}
+      items:
+      {{- range .files }}
+        - key: {{ .filename }}
+          path: {{ .filename }}
+      {{- end }}
+  {{- end }}
+  {{- range .Values.externalVolumes }}
+  - name: "{{ .name }}"
+    persistentVolumeClaim:
+      claimName: {{ .name }}
+  {{- end }}
+  {{- range .Values.hostVolumes }}
+  - name: {{ .name }}
+    hostPath:
+      path: {{ .hostPath }}
+  {{- end }}
+{{- with .Values.nodeSelector }}
+nodeSelector:
+  {{- toYaml . | nindent 2 }}
+{{- end }}
+{{- with .Values.affinity }}
+affinity:
+  {{- toYaml . | nindent 2 }}
+{{- end }}
+{{- with .Values.tolerations }}
+tolerations:
+  {{- toYaml . | nindent 2 }}
+{{- end }}
+{{- end }}

--- a/charts/generic/templates/workload.yaml
+++ b/charts/generic/templates/workload.yaml
@@ -1,3 +1,4 @@
+{{- if or (eq .Values.mode "deployment") (eq .Values.mode "stateful") -}}
 {{- $fullName := include "generic.fullname" . -}}
 {{- $shortName := include "generic.shortname" . -}}
 {{- $isDeployment := eq .Values.mode "deployment" }}
@@ -424,3 +425,4 @@ spec:
         {{- end }}
     {{- end }}
   {{- end }}
+{{- end }}

--- a/charts/generic/test-values-cronjob.yaml
+++ b/charts/generic/test-values-cronjob.yaml
@@ -1,0 +1,11 @@
+mode: cronjob
+image:
+  repository: busybox
+  tag: latest
+  pullPolicy: IfNotPresent
+deployment:
+  command: ["echo"]
+  args: ["helm cronjob test successful"]
+job:
+  schedule: "*/5 * * * *"
+  restartPolicy: OnFailure

--- a/charts/generic/test-values-job.yaml
+++ b/charts/generic/test-values-job.yaml
@@ -1,0 +1,11 @@
+mode: job
+image:
+  repository: busybox
+  tag: latest
+  pullPolicy: IfNotPresent
+deployment:
+  command: ["echo"]
+  args: ["helm job test successful"]
+job:
+  restartPolicy: Never
+  backoffLimit: 1

--- a/charts/generic/values.yaml
+++ b/charts/generic/values.yaml
@@ -2,7 +2,7 @@
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
 
-# Mode can be "deployment" (default) or "stateful" (for StatefulSet)
+# Mode can be "deployment" (default), "stateful" (StatefulSet), "job" (one-time Job run on each deploy), or "cronjob" (scheduled CronJob)
 mode: deployment
 
 replicaCount: 1
@@ -367,6 +367,21 @@ autoscaling:
   maxReplicas: 100
   targetCPUUtilizationPercentage: 80
   # targetMemoryUtilizationPercentage: 80
+
+# Job/CronJob configuration - used when mode is "job" or "cronjob"
+job:
+  restartPolicy: Never            # Never or OnFailure. Use Never to create a new pod on each retry; use OnFailure to restart the same pod
+  backoffLimit: 6                 # Number of times the job will retry before marking it as failed
+  activeDeadlineSeconds: ""       # Optional: max seconds the job is allowed to run before being terminated
+  ttlSecondsAfterFinished: ""     # Optional: seconds after completion before the Job is auto-deleted (requires TTLAfterFinished feature gate)
+  completions: 1                  # Number of pods that must complete successfully for the job to be considered done
+  parallelism: 1                  # Number of pods that can run in parallel at any given time
+  # CronJob-specific settings (only used when mode: "cronjob")
+  schedule: ""                    # Required for cronjob mode, e.g. "*/5 * * * *" or "0 2 * * *"
+  concurrencyPolicy: Forbid       # How to handle overlapping runs: Allow (run concurrently), Forbid (skip new run), or Replace (cancel current, start new)
+  successfulJobsHistoryLimit: 3   # Number of successfully completed jobs to retain for inspection
+  failedJobsHistoryLimit: 1       # Number of failed jobs to retain for inspection
+  suspend: false                  # Set to true to pause scheduling of new jobs without deleting the CronJob
 
 nodeSelector: {}
 


### PR DESCRIPTION
## Summary

- Adds \`mode: "job"\` to run one-time Jobs on every \`helm install\`/\`helm upgrade\` via Helm post-install/post-upgrade hooks with \`before-hook-creation\` delete policy, so each deploy deletes the previous Job and runs a fresh one
- Adds \`mode: "cronjob"\` for scheduled CronJobs, with a required \`job.schedule\` field and standard CronJob controls (concurrencyPolicy, history limits, suspend)
- New \`job:\` values block with settings for both modes: backoffLimit, restartPolicy, completions, parallelism, activeDeadlineSeconds, ttlSecondsAfterFinished
- Guards \`workload.yaml\` so it only renders for deployment/stateful modes
- Adds CI tests covering Job structure/hook annotations, actual cluster install+upgrade re-run behavior, CronJob structure, and missing-schedule validation

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces new workload types and Helm hook behavior that can affect deploy/upgrade semantics and resource lifecycle, though changes are scoped to opt-in `mode` values and are covered by new CI tests.
> 
> **Overview**
> Adds `mode: job` and `mode: cronjob` to the `generic` Helm chart, introducing a new `job.yaml` template that renders either a Helm-hooked one-shot Job (post-install/post-upgrade with `before-hook-creation`) or a standard scheduled CronJob with required `job.schedule` validation.
> 
> Updates `workload.yaml` to only render for deployment/stateful modes, bumps chart version to `1.29.0`, adds a new `job:` values block plus example test values files, and extends the `install-charts` GitHub Actions workflow to template/install/upgrade-test both job and cronjob modes (including validation for missing cron schedule).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2a10e70e453af409566bfaf80c26e8b2b5f2cca6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->