### PR TITLE
Add PodDisruptionBudget support to generic chart

### DIFF
--- a/charts/generic/templates/pdb.yaml
+++ b/charts/generic/templates/pdb.yaml
@@ -1,0 +1,21 @@
+{{- if .Values.podDisruptionBudget.enabled }}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "generic.fullname" . }}
+  labels:
+    {{- include "generic.labels" . | nindent 4 }}
+spec:
+  {{- with .Values.podDisruptionBudget.minAvailable }}
+  minAvailable: {{ . }}
+  {{- end }}
+  {{- with .Values.podDisruptionBudget.maxUnavailable }}
+  maxUnavailable: {{ . }}
+  {{- end }}
+  {{- if .Values.podDisruptionBudget.unhealthyPodEvictionPolicy }}
+  unhealthyPodEvictionPolicy: {{ .Values.podDisruptionBudget.unhealthyPodEvictionPolicy }}
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "generic.selectorLabels" . | nindent 6 }}
+{{- end }}

--- a/charts/generic/values.yaml
+++ b/charts/generic/values.yaml
@@ -368,6 +368,13 @@ autoscaling:
   targetCPUUtilizationPercentage: 80
   # targetMemoryUtilizationPercentage: 80
 
+podDisruptionBudget:
+  enabled: false
+  maxUnavailable: 1
+  # minAvailable and maxUnavailable are mutually exclusive — set only one
+  # minAvailable: 1
+  # unhealthyPodEvictionPolicy: IfHealthy
+
 # Job/CronJob configuration - used when mode is "job" or "cronjob"
 job:
   restartPolicy: Never            # Never or OnFailure. Use Never to create a new pod on each retry; use OnFailure to restart the same pod


### PR DESCRIPTION
## Summary

- Adds a new `podDisruptionBudget` section to the generic chart values with `enabled`, `minAvailable`, `maxUnavailable`, and `unhealthyPodEvictionPolicy` options
- Creates `pdb.yaml` template using `policy/v1` API, gated behind `podDisruptionBudget.enabled`, matching pods via the chart's standard selector labels

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds an optional `PodDisruptionBudget` resource to the generic Helm chart; default remains disabled so existing installs are unaffected unless explicitly enabled. Main risk is misconfiguration if both `minAvailable` and `maxUnavailable` are set, which could cause invalid PDB manifests.
> 
> **Overview**
> Adds optional PodDisruptionBudget support to the `generic` Helm chart.
> 
> Introduces a new `podDisruptionBudget` values block (`enabled`, `minAvailable`, `maxUnavailable`, `unhealthyPodEvictionPolicy`) and a gated `templates/pdb.yaml` that renders a `policy/v1` `PodDisruptionBudget` selecting pods via the chart’s standard selector labels.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 716346a6e71057a5ab1fc78eceec3ce8c765ebf5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->