### PR TITLE
Update chart version, change PDB template

### DIFF
--- a/charts/generic/Chart.yaml
+++ b/charts/generic/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: generic
 description: A generic helm chart that handles a bunch of common application deploy cases
 type: application
-version: 1.29.0
+version: 1.30.0

--- a/charts/generic/templates/pdb.yaml
+++ b/charts/generic/templates/pdb.yaml
@@ -6,11 +6,11 @@ metadata:
   labels:
     {{- include "generic.labels" . | nindent 4 }}
 spec:
-  {{- with .Values.podDisruptionBudget.minAvailable }}
-  minAvailable: {{ . }}
+  {{- if not (kindIs "invalid" .Values.podDisruptionBudget.minAvailable) }}
+  minAvailable: {{ .Values.podDisruptionBudget.minAvailable }}
   {{- end }}
-  {{- with .Values.podDisruptionBudget.maxUnavailable }}
-  maxUnavailable: {{ . }}
+  {{- if not (kindIs "invalid" .Values.podDisruptionBudget.maxUnavailable) }}
+  maxUnavailable: {{ .Values.podDisruptionBudget.maxUnavailable }}
   {{- end }}
   {{- if .Values.podDisruptionBudget.unhealthyPodEvictionPolicy }}
   unhealthyPodEvictionPolicy: {{ .Values.podDisruptionBudget.unhealthyPodEvictionPolicy }}

--- a/charts/generic/values.yaml
+++ b/charts/generic/values.yaml
@@ -370,8 +370,8 @@ autoscaling:
 
 podDisruptionBudget:
   enabled: false
-  maxUnavailable: 1
   # minAvailable and maxUnavailable are mutually exclusive — set only one
+  maxUnavailable: 1
   # minAvailable: 1
   # unhealthyPodEvictionPolicy: IfHealthy
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes PodDisruptionBudget templating behavior, which can alter eviction/availability guarantees for workloads when users set `minAvailable`/`maxUnavailable` to falsy values like `0`. Scope is small and isolated to chart templating.
> 
> **Overview**
> Bumps the `generic` Helm chart version to `1.30.0`.
> 
> Updates the `PodDisruptionBudget` template to render `spec.minAvailable` and `spec.maxUnavailable` based on whether the values are *defined* (via `kindIs "invalid"`) rather than Helm’s truthiness checks, allowing explicitly-set values like `0` to be honored.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e5729bc2536736cb4649dde1b35f97f2038c71d3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->