### PR TITLE
Add OCI chart publishing

### DIFF
--- a/.github/workflows/publish-charts.yaml
+++ b/.github/workflows/publish-charts.yaml
@@ -36,6 +36,7 @@ jobs:
 
   publish-oci:
     permissions:
+      contents: read
       packages: write
     runs-on: ubuntu-latest
     steps:
@@ -52,9 +53,9 @@ jobs:
         run: |
           owner=$(echo "${{ github.repository_owner }}" | tr '[:upper:]' '[:lower:]')
           for chart in charts/*/; do
-            name=$(basename "$chart")
+            name=$(grep '^name:' "$chart/Chart.yaml" | awk '{print $2}')
             version=$(grep '^version:' "$chart/Chart.yaml" | awk '{print $2}')
-            if helm pull "oci://ghcr.io/${owner}/helm-charts/${name}" --version "$version" 2>/dev/null; then
+            if helm show chart "oci://ghcr.io/${owner}/helm-charts/${name}" --version "$version" > /dev/null 2>&1; then
               echo "::notice::${name}@${version} already exists in OCI registry, skipping"
               continue
             fi

--- a/.github/workflows/publish-charts.yaml
+++ b/.github/workflows/publish-charts.yaml
@@ -54,7 +54,7 @@ jobs:
           for chart in charts/*/; do
             name=$(basename "$chart")
             version=$(grep '^version:' "$chart/Chart.yaml" | awk '{print $2}')
-            if helm pull "oci://ghcr.io/${owner}/charts/${name}" --version "$version" 2>/dev/null; then
+            if helm pull "oci://ghcr.io/${owner}/helm-charts/${name}" --version "$version" 2>/dev/null; then
               echo "::notice::${name}@${version} already exists in OCI registry, skipping"
               continue
             fi

--- a/.github/workflows/publish-charts.yaml
+++ b/.github/workflows/publish-charts.yaml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
@@ -33,3 +33,31 @@ jobs:
         uses: helm/chart-releaser-action@v1
         env:
           CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+
+  publish-oci:
+    permissions:
+      packages: write
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Install Helm
+        uses: azure/setup-helm@v4
+
+      - name: Login to GHCR
+        run: echo "${{ secrets.GITHUB_TOKEN }}" | helm registry login ghcr.io -u "${{ github.actor }}" --password-stdin
+
+      - name: Package and push charts
+        run: |
+          owner=$(echo "${{ github.repository_owner }}" | tr '[:upper:]' '[:lower:]')
+          for chart in charts/*/; do
+            name=$(basename "$chart")
+            version=$(grep '^version:' "$chart/Chart.yaml" | awk '{print $2}')
+            if helm pull "oci://ghcr.io/${owner}/charts/${name}" --version "$version" 2>/dev/null; then
+              echo "::notice::${name}@${version} already exists in OCI registry, skipping"
+              continue
+            fi
+            helm package "$chart"
+            helm push "${name}-${version}.tgz" "oci://ghcr.io/${owner}/helm-charts"
+          done


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes the `main` push workflow to also publish charts to GHCR via OCI, which can affect release/publishing behavior and permissions if misconfigured.
> 
> **Overview**
> Adds a new `publish-oci` GitHub Actions job that logs into GHCR, packages each chart in `charts/*`, skips versions that already exist, and pushes them to `oci://ghcr.io/<owner>/helm-charts`.
> 
> Updates workflow dependencies by bumping `actions/checkout` to `v6` and using `azure/setup-helm@v4` for the OCI publishing job (while keeping the existing `chart-releaser` job intact).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a2e4ed3d084b84aa7484c28e416b11d65fbef97f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->