### PR TITLE
generic: Comment out default maxUnavailable in PodDisruptionBudget so consumer can decide which option to set

### DIFF
--- a/charts/generic/Chart.yaml
+++ b/charts/generic/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: generic
 description: A generic helm chart that handles a bunch of common application deploy cases
 type: application
-version: 1.30.0
+version: 1.30.1

--- a/charts/generic/templates/pdb.yaml
+++ b/charts/generic/templates/pdb.yaml
@@ -1,4 +1,10 @@
 {{- if .Values.podDisruptionBudget.enabled }}
+{{- if and (kindIs "invalid" .Values.podDisruptionBudget.minAvailable) (kindIs "invalid" .Values.podDisruptionBudget.maxUnavailable) }}
+{{- fail "podDisruptionBudget.enabled is true but neither podDisruptionBudget.minAvailable nor podDisruptionBudget.maxUnavailable is set. Set exactly one to avoid a PDB that blocks all voluntary disruptions (disruptionsAllowed: 0)." }}
+{{- end }}
+{{- if and (not (kindIs "invalid" .Values.podDisruptionBudget.minAvailable)) (not (kindIs "invalid" .Values.podDisruptionBudget.maxUnavailable)) }}
+{{- fail "podDisruptionBudget.minAvailable and podDisruptionBudget.maxUnavailable are mutually exclusive — set only one." }}
+{{- end }}
 apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:

--- a/charts/generic/values.yaml
+++ b/charts/generic/values.yaml
@@ -371,7 +371,7 @@ autoscaling:
 podDisruptionBudget:
   enabled: false
   # minAvailable and maxUnavailable are mutually exclusive — set only one
-  maxUnavailable: 1
+  # maxUnavailable: 1
   # minAvailable: 1
   # unhealthyPodEvictionPolicy: IfHealthy
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Medium risk because it changes chart defaults and introduces render-time `fail` checks that can break existing releases that enabled PDBs without explicitly setting exactly one of the two fields.
> 
> **Overview**
> Updates the `generic` Helm chart to make PodDisruptionBudget configuration explicit: the default `podDisruptionBudget.maxUnavailable` value is commented out so consumers must choose a policy.
> 
> When `podDisruptionBudget.enabled` is true, the PDB template now hard-fails rendering if **neither** `minAvailable` nor `maxUnavailable` is set, or if **both** are set, preventing accidental PDBs that block all voluntary disruptions. Chart version is bumped to `1.30.1`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8a11220b016bb6116eeab4c2105a6407281ff96f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->