### PR TITLE
generic: Add Gateway API ListenerSet, and cert-manager Certificate support

### DIFF
--- a/.github/workflows/install-charts.yaml
+++ b/.github/workflows/install-charts.yaml
@@ -298,6 +298,117 @@ jobs:
             exit 1
           fi
 
+      - name: Test certificates - verify no Certificate created by default
+        run: |
+          helm template test ./charts/generic > /tmp/cert-default-output.yaml
+          if grep -q "kind: Certificate" /tmp/cert-default-output.yaml; then
+            echo "✗ Unexpected Certificate found in default values output"
+            exit 1
+          else
+            echo "✓ No Certificate created by default (correct)"
+          fi
+
+      - name: Test certificates - verify Certificates can be created
+        run: |
+          helm template test ./charts/generic -f ./charts/generic/test-values-certificates.yaml > /tmp/cert-output.yaml
+          CERT_COUNT=$(grep -c "kind: Certificate" /tmp/cert-output.yaml || echo "0")
+          if [ "$CERT_COUNT" -eq 2 ]; then
+            echo "✓ Correctly created 2 Certificates"
+          else
+            echo "✗ Expected 2 Certificates, found $CERT_COUNT"
+            exit 1
+          fi
+          if grep -q "apiVersion: cert-manager.io/v1" /tmp/cert-output.yaml; then
+            echo "✓ Certificate uses cert-manager.io/v1 apiVersion"
+          else
+            echo "✗ Certificate apiVersion not found"
+            exit 1
+          fi
+          if grep -q "name: test-cert-primary" /tmp/cert-output.yaml; then
+            echo "✓ Named Certificate has correct name"
+          else
+            echo "✗ Named Certificate not found"
+            exit 1
+          fi
+          if grep -q "secretName: test-cert-primary-tls" /tmp/cert-output.yaml; then
+            echo "✓ Certificate spec passed through correctly"
+          else
+            echo "✗ Certificate spec not passed through"
+            exit 1
+          fi
+
+      - name: Test certificates - missing spec should fail
+        run: |
+          set +e
+          helm template test ./charts/generic --set 'certificates[0].name=missing-spec' 2>&1 | tee /tmp/cert-missing-spec.txt
+          EXIT_CODE=${PIPESTATUS[0]}
+          set -e
+          if [ $EXIT_CODE -eq 0 ]; then
+            echo "✗ Expected validation failure for certificate without spec, but helm template succeeded"
+            exit 1
+          fi
+          if grep -q "certificates\[0\].spec is required" /tmp/cert-missing-spec.txt; then
+            echo "✓ Validation correctly failed with expected error message"
+          else
+            echo "✗ Validation failed but with unexpected error message"
+            cat /tmp/cert-missing-spec.txt
+            exit 1
+          fi
+
+      - name: Test ListenerSet - verify no ListenerSet created by default
+        run: |
+          helm template test ./charts/generic > /tmp/ls-default-output.yaml
+          if grep -q "kind: ListenerSet" /tmp/ls-default-output.yaml; then
+            echo "✗ Unexpected ListenerSet found in default values output"
+            exit 1
+          else
+            echo "✓ No ListenerSet created by default (correct)"
+          fi
+
+      - name: Test ListenerSet - verify ListenerSet can be created
+        run: |
+          helm template test ./charts/generic -f ./charts/generic/test-values-listenerset.yaml > /tmp/ls-output.yaml
+          if grep -q "kind: ListenerSet" /tmp/ls-output.yaml; then
+            echo "✓ ListenerSet resource found"
+          else
+            echo "✗ ListenerSet resource not found"
+            exit 1
+          fi
+          if grep -q "apiVersion: gateway.networking.k8s.io/v1" /tmp/ls-output.yaml; then
+            echo "✓ ListenerSet uses standard channel apiVersion"
+          else
+            echo "✗ ListenerSet apiVersion not found"
+            exit 1
+          fi
+          if grep -q "name: parent-gateway" /tmp/ls-output.yaml; then
+            echo "✓ parentRef rendered correctly"
+          else
+            echo "✗ parentRef not rendered"
+            exit 1
+          fi
+          if grep -q "protocol: HTTPS" /tmp/ls-output.yaml && grep -q "protocol: HTTP" /tmp/ls-output.yaml; then
+            echo "✓ Listeners rendered correctly"
+          else
+            echo "✗ Listeners not rendered as expected"
+            exit 1
+          fi
+
+      - name: Test ListenerSet - experimental channel override
+        run: |
+          helm template test ./charts/generic \
+            --set gatewayAPI.listenerSet.enabled=true \
+            --set gatewayAPI.listenerSet.apiVersion=gateway.networking.x-k8s.io/v1alpha1 \
+            --set gatewayAPI.listenerSet.kind=XListenerSet \
+            --set gatewayAPI.listenerSet.parentRef.name=parent-gateway > /tmp/ls-experimental-output.yaml
+          if grep -q "kind: XListenerSet" /tmp/ls-experimental-output.yaml && \
+             grep -q "apiVersion: gateway.networking.x-k8s.io/v1alpha1" /tmp/ls-experimental-output.yaml; then
+            echo "✓ Experimental ListenerSet apiVersion/kind override works"
+          else
+            echo "✗ Experimental override did not render correctly"
+            cat /tmp/ls-experimental-output.yaml
+            exit 1
+          fi
+
       - name: Install generic-stateful chart
         uses: Chia-Network/actions/helm/deploy@main
         with:

--- a/charts/generic/Chart.yaml
+++ b/charts/generic/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: generic
 description: A generic helm chart that handles a bunch of common application deploy cases
 type: application
-version: 1.30.1
+version: 1.31.0

--- a/charts/generic/templates/certificate.yaml
+++ b/charts/generic/templates/certificate.yaml
@@ -1,0 +1,33 @@
+{{- if .Values.certificates }}
+{{- $fullName := include "generic.fullname" . -}}
+{{- $count := len .Values.certificates -}}
+{{- range $i, $cert := .Values.certificates }}
+{{- $name := $cert.name }}
+{{- if not $name }}
+{{- if eq $count 1 }}
+{{- $name = $fullName }}
+{{- else }}
+{{- $name = printf "%s-%d" $fullName $i }}
+{{- end }}
+{{- end }}
+{{- if not $cert.spec }}
+{{- fail (printf "certificates[%d].spec is required" $i) }}
+{{- end }}
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: {{ $name }}
+  labels:
+    {{- include "generic.labels" $ | nindent 4 }}
+    {{- with $cert.additionalLabels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- with $cert.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- toYaml $cert.spec | nindent 2 }}
+{{- end }}
+{{- end }}

--- a/charts/generic/templates/listenerset.yaml
+++ b/charts/generic/templates/listenerset.yaml
@@ -1,0 +1,23 @@
+{{- if .Values.gatewayAPI.listenerSet.enabled -}}
+{{- $fullName := include "generic.fullname" . -}}
+apiVersion: {{ .Values.gatewayAPI.listenerSet.apiVersion | default "gateway.networking.k8s.io/v1" }}
+kind: {{ .Values.gatewayAPI.listenerSet.kind | default "ListenerSet" }}
+metadata:
+  name: {{ $fullName }}
+  labels:
+    {{- include "generic.labels" . | nindent 4 }}
+    {{- with .Values.gatewayAPI.listenerSet.additionalLabels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- with .Values.gatewayAPI.listenerSet.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  parentRef:
+    {{- toYaml .Values.gatewayAPI.listenerSet.parentRef | nindent 4 }}
+  {{- with .Values.gatewayAPI.listenerSet.listeners }}
+  listeners:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/charts/generic/test-values-certificates.yaml
+++ b/charts/generic/test-values-certificates.yaml
@@ -1,0 +1,37 @@
+# Test values to verify cert-manager Certificate resources are rendered
+mode: deployment
+replicaCount: 1
+image:
+  repository: nginx
+  tag: latest
+deployment:
+  containerPort: 80
+  containerPortName: http
+certificates:
+  - name: test-cert-primary
+    additionalLabels:
+      cert-tier: primary
+    annotations:
+      cert-manager.io/test: "true"
+    spec:
+      secretName: test-cert-primary-tls
+      commonName: primary.example.com
+      dnsNames:
+        - primary.example.com
+        - www.primary.example.com
+      issuerRef:
+        name: letsencrypt
+        kind: ClusterIssuer
+        group: cert-manager.io
+      duration: 2160h
+      renewBefore: 360h
+      usages:
+        - server auth
+        - client auth
+  - spec:
+      secretName: test-cert-secondary-tls
+      dnsNames:
+        - secondary.example.com
+      issuerRef:
+        name: selfsigned
+        kind: Issuer

--- a/charts/generic/test-values-listenerset.yaml
+++ b/charts/generic/test-values-listenerset.yaml
@@ -1,0 +1,36 @@
+# Test values to verify Gateway API ListenerSet rendering
+mode: deployment
+replicaCount: 1
+image:
+  repository: nginx
+  tag: latest
+deployment:
+  containerPort: 80
+  containerPortName: http
+gatewayAPI:
+  listenerSet:
+    enabled: true
+    annotations:
+      gateway.k8s.io/test: "true"
+    additionalLabels:
+      listener-tier: edge
+    parentRef:
+      group: gateway.networking.k8s.io
+      kind: Gateway
+      name: parent-gateway
+      namespace: gateway-system
+    listeners:
+      - name: https
+        hostname: chart-example.local
+        port: 443
+        protocol: HTTPS
+        tls:
+          mode: Terminate
+          certificateRefs:
+            - name: chart-example-tls
+              kind: Secret
+              group: ""
+      - name: http
+        hostname: chart-example.local
+        port: 80
+        protocol: HTTP

--- a/charts/generic/values.yaml
+++ b/charts/generic/values.yaml
@@ -193,6 +193,66 @@ gatewayAPI:
     # See the HTTPRoute documentation for configuration details: https://gateway-api.sigs.k8s.io/api-types/httproute/
     # rules: {}
 
+  # ListenerSet (GEP-1713) attaches additional listeners to an existing Gateway.
+  # The parent Gateway must allow ListenerSet attachment via spec.allowedListeners.
+  # See: https://gateway-api.sigs.k8s.io/api-types/listenerset/
+  listenerSet:
+    enabled: false
+    # ListenerSet has been a Standard Channel resource since gateway-api v1.5.0
+    # (apiVersion: gateway.networking.k8s.io/v1, kind: ListenerSet).
+    # Override these to use the experimental channel
+    # (gateway.networking.x-k8s.io/v1alpha1, kind: XListenerSet).
+    apiVersion: gateway.networking.k8s.io/v1
+    kind: ListenerSet
+    annotations: {}
+    additionalLabels: {}
+    # The Gateway this ListenerSet attaches to.
+    parentRef:
+      group: gateway.networking.k8s.io
+      kind: Gateway
+      # Uncomment the following lines and change the values to point to your gateway
+      # name: default
+      # namespace: gateway-system
+    # List of listeners to attach to the parent Gateway. Provided to the
+    # ListenerSet spec as-is. See ListenerSet docs for field reference.
+    listeners: []
+    #  - name: https
+    #    hostname: chart-example.local
+    #    port: 443
+    #    protocol: HTTPS
+    #    tls:
+    #      mode: Terminate
+    #      certificateRefs:
+    #        - name: chart-example-tls
+    #          kind: Secret
+    #          group: ""
+
+# cert-manager Certificate resources (cert-manager.io/v1).
+# Each entry creates one Certificate. The full Certificate spec is passed through
+# as-is, so any field supported by cert-manager can be set here.
+# See: https://cert-manager.io/docs/usage/certificate/
+certificates: []
+#  - # Optional. Defaults to the chart fullname (with an index suffix if multiple).
+#    name: ""
+#    annotations: {}
+#    additionalLabels: {}
+#    # The Certificate spec — passed through to the resource as-is.
+#    spec:
+#      secretName: chart-example-tls
+#      commonName: chart-example.local
+#      dnsNames:
+#        - chart-example.local
+#        - www.chart-example.local
+#      issuerRef:
+#        name: letsencrypt
+#        kind: ClusterIssuer
+#        group: cert-manager.io
+#      # duration: 2160h
+#      # renewBefore: 360h
+#      # usages:
+#      #   - server auth
+#      #   - client auth
+
 networkPolicy:
   enabled: false
   policyTypes: []


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Adds new optional templated Kubernetes resources to the `generic` Helm chart (cert-manager `Certificate` and Gateway API `ListenerSet`), which could change rendered manifests when enabled and introduces new validation failures for misconfigured values.
> 
> **Overview**
> Adds optional support in the `generic` Helm chart to render **cert-manager `Certificate` resources** from a new top-level `certificates[]` values list (including default naming, extra labels/annotations, and a hard fail when `spec` is missing).
> 
> Adds optional **Gateway API `ListenerSet` rendering** under `gatewayAPI.listenerSet`, including configurable `apiVersion`/`kind` (standard vs experimental) and pass-through `parentRef`/`listeners`.
> 
> Bumps the chart version to `1.31.0` and extends the GitHub Actions chart validation workflow to template-test the new resources and their expected failure cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4860aeb833fa82ed8dca2deb1bbe068e4bac1217. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->