### PR TITLE
Document generic chart metrics port wiring for Prometheus

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,3 +5,13 @@
 ```shell
 helm repo add chia-network https://chia-network.github.io/helm-charts
 ```
+
+## Prometheus metrics (`charts/generic`)
+
+To expose `/metrics` for Prometheus Operator scrapes, wire **container port → Service port → ServiceMonitor** with a consistent port **name** `metrics`:
+
+1. **`deployment.additionalPorts`** — add a named port, e.g. `- name: metrics`, `containerPort: <listener>`, `protocol: TCP`.
+2. **`service.additionalPorts`** — expose the same path with `name: metrics`, `port: <listener>` (or another cluster port), and `targetPort: metrics` (string name matching the container port name).
+3. **`serviceMonitor`** — set `enabled: true`. `endpointPort` defaults to `metrics` and must match the **Service** port name (not the container port number).
+
+If the target cluster does not install `monitoring.coreos.com/v1` ServiceMonitors, leave `serviceMonitor.enabled` false and scrape via static config or another mechanism.


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Documentation-only change that clarifies how to expose `/metrics` via named ports and `ServiceMonitor`; no runtime behavior is modified.
> 
> **Overview**
> Adds a new README section documenting how to expose `/metrics` for `charts/generic` with Prometheus Operator by consistently wiring a named `metrics` port from `deployment.additionalPorts` through `service.additionalPorts` to the `serviceMonitor` `endpointPort`, and notes the fallback when ServiceMonitors aren’t installed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7e9e97b122b327dda976a23663cc66dcac415443. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->