### PR TITLE
Allow adding additional selector labels to the extra services

### DIFF
--- a/charts/generic/Chart.yaml
+++ b/charts/generic/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: generic
 description: A generic helm chart that handles a bunch of common application deploy cases
 type: application
-version: 1.30.1
+version: 1.31.0

--- a/charts/generic/templates/additionalServices.yaml
+++ b/charts/generic/templates/additionalServices.yaml
@@ -24,6 +24,9 @@ spec:
     {{- toYaml $svc.ports | nindent 4 }}
   selector:
     {{- include "generic.selectorLabels" $ | nindent 4 }}
+    {{- with $svc.additionalSelectorLabels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
 {{- end }}
 {{- end }}
 {{- end }}

--- a/charts/generic/values.yaml
+++ b/charts/generic/values.yaml
@@ -143,6 +143,8 @@ additionalServices: []
 #    additionalLabels: {}
 #    # application: my-application
 #    # prometheus: application-metrics
+#    additionalSelectorLabels: {}
+#      # role: metrics
 #    annotations: {}
 #    # external-dns.alpha.kubernetes.io/hostname: testing.example.com
 #    ports:


### PR DESCRIPTION
Not allowing on the primary service right now, since its fairly easy to just break the app with extra labels, but there are random cases where secondary services might need them (leader labels, etc)