### PR TITLE
Option for share process namespace

### DIFF
--- a/charts/generic/Chart.yaml
+++ b/charts/generic/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: generic
 description: A generic helm chart that handles a bunch of common application deploy cases
 type: application
-version: 1.31.0
+version: 1.32.0

--- a/charts/generic/templates/workload.yaml
+++ b/charts/generic/templates/workload.yaml
@@ -43,6 +43,9 @@ spec:
       serviceAccountName: {{ include "generic.serviceAccountName" . }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      {{- if .Values.shareProcessNamespace }}
+      shareProcessNamespace: true
+      {{- end }}
       {{- with .Values.initContainers }}
       initContainers:
       {{- range $.Values.initContainers }}

--- a/charts/generic/values.yaml
+++ b/charts/generic/values.yaml
@@ -73,6 +73,10 @@ podAnnotations: {}
 podSecurityContext: {}
   # fsGroup: 2000
 
+# When true, containers in the pod share a process namespace (needed for a sidecar
+# to signal processes in another container, e.g. SIGTERM on leader demotion).
+shareProcessNamespace: false
+
 securityContext: {}
   # capabilities:
   #   drop:


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Opt-in with default false; only affects pod spec when explicitly enabled, though shared namespaces weaken container process isolation.
> 
> **Overview**
> Adds an opt-in **`shareProcessNamespace`** value (default **`false`**) to the generic chart and bumps the chart to **1.32.0**.
> 
> When enabled, Deployment and StatefulSet pod templates in **`workload.yaml`** set **`shareProcessNamespace: true`**, so containers in the pod share a process namespace—documented for sidecars that need to signal processes in another container (e.g. **SIGTERM** on leader demotion). Existing releases are unchanged unless consumers set the flag.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 14941aaea1e5ff15b8207e989a708a01398b659d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->