### PR TITLE
Add HTTPProxy and Certificate to the generic helm chart

### DIFF
--- a/.github/workflows/install-charts.yaml
+++ b/.github/workflows/install-charts.yaml
@@ -402,6 +402,28 @@ jobs:
             exit 1
           fi
 
+      - name: Test Contour HTTPProxy - TLS passthrough uses tcpproxy, not HTTP routes
+        run: |
+          helm template test ./charts/generic \
+            --set service.enabled=true \
+            --set contour.httpProxy.enabled=true \
+            --set contour.httpProxy.fqdn=passthrough.example.com \
+            --set contour.httpProxy.tls.passthrough=true > /tmp/httpproxy-passthrough.yaml
+          if grep -q "tcpproxy:" /tmp/httpproxy-passthrough.yaml; then
+            echo "✓ Passthrough HTTPProxy routes via tcpproxy"
+          else
+            echo "✗ Passthrough HTTPProxy missing tcpproxy"
+            cat /tmp/httpproxy-passthrough.yaml
+            exit 1
+          fi
+          if grep -q "routes:" /tmp/httpproxy-passthrough.yaml; then
+            echo "✗ Passthrough HTTPProxy should not render HTTP routes"
+            cat /tmp/httpproxy-passthrough.yaml
+            exit 1
+          else
+            echo "✓ Passthrough HTTPProxy does not render HTTP routes"
+          fi
+
       - name: Test certificates - verify Certificates can be created
         run: |
           helm template test ./charts/generic -f ./charts/generic/test-values-certificates.yaml > /tmp/cert-output.yaml

--- a/.github/workflows/install-charts.yaml
+++ b/.github/workflows/install-charts.yaml
@@ -323,6 +323,13 @@ jobs:
             cat /tmp/contour-cert-output.yaml
             exit 1
           fi
+          if grep -q "apiVersion: cert-manager.io/v1" /tmp/contour-cert-output.yaml; then
+            echo "✓ Certificate uses cert-manager.io/v1 apiVersion"
+          else
+            echo "✗ Certificate apiVersion not found"
+            cat /tmp/contour-cert-output.yaml
+            exit 1
+          fi
           if grep -q "secretName: test-tls" /tmp/contour-cert-output.yaml; then
             echo "✓ Certificate/HTTPProxy default tls secret name (<release>-tls) rendered"
           else
@@ -395,23 +402,58 @@ jobs:
             exit 1
           fi
 
-      - name: Test cert-manager Certificate - missing dnsNames should fail
+      - name: Test certificates - verify Certificates can be created
+        run: |
+          helm template test ./charts/generic -f ./charts/generic/test-values-certificates.yaml > /tmp/cert-output.yaml
+          CERT_COUNT=$(grep -c "kind: Certificate" /tmp/cert-output.yaml || echo "0")
+          if [ "$CERT_COUNT" -eq 2 ]; then
+            echo "✓ Correctly created 2 Certificates"
+          else
+            echo "✗ Expected 2 Certificates, found $CERT_COUNT"
+            exit 1
+          fi
+          if grep -q "apiVersion: cert-manager.io/v1" /tmp/cert-output.yaml; then
+            echo "✓ Certificate uses cert-manager.io/v1 apiVersion"
+          else
+            echo "✗ Certificate apiVersion not found"
+            exit 1
+          fi
+          if grep -q "name: test-cert-primary" /tmp/cert-output.yaml; then
+            echo "✓ Named Certificate has correct name"
+          else
+            echo "✗ Named Certificate not found"
+            exit 1
+          fi
+          if grep -q "secretName: test-cert-primary-tls" /tmp/cert-output.yaml; then
+            echo "✓ Certificate spec passed through correctly"
+          else
+            echo "✗ Certificate spec not passed through"
+            exit 1
+          fi
+          # Unnamed second entry must fall back to an indexed fullname
+          if grep -q "name: test-generic-1" /tmp/cert-output.yaml; then
+            echo "✓ Unnamed Certificate defaults to indexed fullname"
+          else
+            echo "✗ Unnamed Certificate name not defaulted as expected"
+            cat /tmp/cert-output.yaml
+            exit 1
+          fi
+
+      - name: Test certificates - missing spec should fail
         run: |
           set +e
-          helm template test ./charts/generic \
-            --set certManager.certificate.enabled=true \
-            --set certManager.certificate.issuerRef.name=letsencrypt-cf 2>&1 | tee /tmp/cert-no-dns.txt
+          helm template test ./charts/generic --set 'certificates[0].name=missing-spec' 2>&1 | tee /tmp/cert-missing-spec.txt
           EXIT_CODE=${PIPESTATUS[0]}
           set -e
           if [ $EXIT_CODE -eq 0 ]; then
-            echo "✗ Expected validation failure for Certificate without dnsNames, but helm template succeeded"
+            echo "✗ Expected validation failure for certificate without spec, but helm template succeeded"
             exit 1
           fi
-          if grep -q "certManager.certificate.dnsNames is empty" /tmp/cert-no-dns.txt; then
+          if grep -q "certificates\[0\].spec is required" /tmp/cert-missing-spec.txt; then
             echo "✓ Validation correctly failed with expected error message"
           else
             echo "✗ Validation failed but with unexpected error message"
-            cat /tmp/cert-no-dns.txt
+            cat /tmp/cert-missing-spec.txt
             exit 1
           fi
 

--- a/.github/workflows/install-charts.yaml
+++ b/.github/workflows/install-charts.yaml
@@ -298,6 +298,123 @@ jobs:
             exit 1
           fi
 
+      - name: Test Contour HTTPProxy and cert-manager Certificate - verify template structure
+        run: |
+          helm template test ./charts/generic -f ./charts/generic/test-values-contour-cert.yaml > /tmp/contour-cert-output.yaml
+          # Contour HTTPProxy must be rendered
+          if grep -q "kind: HTTPProxy" /tmp/contour-cert-output.yaml; then
+            echo "✓ HTTPProxy resource found"
+          else
+            echo "✗ HTTPProxy resource not found"
+            cat /tmp/contour-cert-output.yaml
+            exit 1
+          fi
+          if grep -q "fqdn: chart-example.local" /tmp/contour-cert-output.yaml; then
+            echo "✓ HTTPProxy virtualhost fqdn rendered"
+          else
+            echo "✗ HTTPProxy virtualhost fqdn not found"
+            exit 1
+          fi
+          # cert-manager Certificate must be rendered into the same tls secret
+          if grep -q "kind: Certificate" /tmp/contour-cert-output.yaml; then
+            echo "✓ Certificate resource found"
+          else
+            echo "✗ Certificate resource not found"
+            cat /tmp/contour-cert-output.yaml
+            exit 1
+          fi
+          if grep -q "secretName: test-tls" /tmp/contour-cert-output.yaml; then
+            echo "✓ Certificate/HTTPProxy default tls secret name (<release>-tls) rendered"
+          else
+            echo "✗ Expected default tls secret name 'test-tls' not found"
+            cat /tmp/contour-cert-output.yaml
+            exit 1
+          fi
+
+      - name: Test Contour/cert-manager disabled by default
+        run: |
+          helm template test ./charts/generic -f ./charts/generic/values.yaml > /tmp/default-output.yaml
+          if grep -q "kind: HTTPProxy" /tmp/default-output.yaml || grep -q "kind: Certificate" /tmp/default-output.yaml; then
+            echo "✗ HTTPProxy/Certificate rendered by default (should be disabled)"
+            exit 1
+          else
+            echo "✓ No HTTPProxy/Certificate rendered by default (correct)"
+          fi
+
+      - name: Test Contour HTTPProxy - default route without a Service should fail
+        run: |
+          set +e
+          helm template test ./charts/generic \
+            --set contour.httpProxy.enabled=true 2>&1 | tee /tmp/httpproxy-no-svc.txt
+          EXIT_CODE=${PIPESTATUS[0]}
+          set -e
+          if [ $EXIT_CODE -eq 0 ]; then
+            echo "✗ Expected validation failure for HTTPProxy default route without a Service, but helm template succeeded"
+            exit 1
+          fi
+          if grep -q "service.enabled is false" /tmp/httpproxy-no-svc.txt; then
+            echo "✓ Validation correctly failed with expected error message"
+          else
+            echo "✗ Validation failed but with unexpected error message"
+            cat /tmp/httpproxy-no-svc.txt
+            exit 1
+          fi
+
+      - name: Test Contour HTTPProxy - empty fqdn should fail
+        run: |
+          set +e
+          helm template test ./charts/generic \
+            --set service.enabled=true \
+            --set contour.httpProxy.enabled=true \
+            --set contour.httpProxy.fqdn="" 2>&1 | tee /tmp/httpproxy-no-fqdn.txt
+          EXIT_CODE=${PIPESTATUS[0]}
+          set -e
+          if [ $EXIT_CODE -eq 0 ]; then
+            echo "✗ Expected validation failure for HTTPProxy with empty fqdn, but helm template succeeded"
+            exit 1
+          fi
+          if grep -q "contour.httpProxy.fqdn is empty" /tmp/httpproxy-no-fqdn.txt; then
+            echo "✓ Validation correctly failed with expected error message"
+          else
+            echo "✗ Validation failed but with unexpected error message"
+            cat /tmp/httpproxy-no-fqdn.txt
+            exit 1
+          fi
+
+      - name: Test Contour HTTPProxy - custom routes without a Service should render
+        run: |
+          helm template test ./charts/generic \
+            --set contour.httpProxy.enabled=true \
+            --set 'contour.httpProxy.routes[0].services[0].name=other-svc' \
+            --set 'contour.httpProxy.routes[0].services[0].port=8080' > /tmp/httpproxy-custom.yaml
+          if grep -q "name: other-svc" /tmp/httpproxy-custom.yaml; then
+            echo "✓ HTTPProxy with custom routes renders without requiring service.enabled"
+          else
+            echo "✗ HTTPProxy custom routes not rendered as expected"
+            cat /tmp/httpproxy-custom.yaml
+            exit 1
+          fi
+
+      - name: Test cert-manager Certificate - missing dnsNames should fail
+        run: |
+          set +e
+          helm template test ./charts/generic \
+            --set certManager.certificate.enabled=true \
+            --set certManager.certificate.issuerRef.name=letsencrypt-cf 2>&1 | tee /tmp/cert-no-dns.txt
+          EXIT_CODE=${PIPESTATUS[0]}
+          set -e
+          if [ $EXIT_CODE -eq 0 ]; then
+            echo "✗ Expected validation failure for Certificate without dnsNames, but helm template succeeded"
+            exit 1
+          fi
+          if grep -q "certManager.certificate.dnsNames is empty" /tmp/cert-no-dns.txt; then
+            echo "✓ Validation correctly failed with expected error message"
+          else
+            echo "✗ Validation failed but with unexpected error message"
+            cat /tmp/cert-no-dns.txt
+            exit 1
+          fi
+
       - name: Install generic-stateful chart
         uses: Chia-Network/actions/helm/deploy@main
         with:

--- a/README.md
+++ b/README.md
@@ -24,8 +24,10 @@ with [cert-manager](https://cert-manager.io/), the chart can render a
 instead of (or alongside) a plain Ingress. Both require the respective CRDs and
 controllers to already be installed in the cluster.
 
-1. **`service.enabled: true`** — the HTTPProxy routes to the chart's Service on
-   `service.port`, so a Service must exist.
+1. **`service.enabled: true`** — the default backend routes to the chart's
+   Service on `service.port`, so a Service must exist. This is only required when
+   using the default route/tcpproxy; if you provide custom `routes` or `tcpproxy`
+   that reference other Services, `service.enabled` is not needed.
 2. **`contour.httpProxy`** — set `enabled: true` and a `fqdn`. By default a
    single route sends `/` to the Service; override `routes` for custom routing.
    With `tls.enabled: true`, Contour terminates TLS using `tls.secretName`

--- a/README.md
+++ b/README.md
@@ -30,13 +30,16 @@ controllers to already be installed in the cluster.
    single route sends `/` to the Service; override `routes` for custom routing.
    With `tls.enabled: true`, Contour terminates TLS using `tls.secretName`
    (defaults to `<release>-tls`).
-3. **`certManager.certificate`** — a cert-manager Certificate. Set `enabled: true`,
-   provide `dnsNames`, and point `issuerRef.name` at a configured
-   `Issuer`/`ClusterIssuer`. cert-manager writes the issued cert/key into
-   `secretName` (defaults to `<release>-tls`), which matches the HTTPProxy/Ingress
-   TLS default so the two line up.
+3. **`certificates`** — a list of cert-manager Certificates. Each entry passes its
+   `spec` through to the resource as-is (any cert-manager field is supported), and
+   `name` defaults to the chart fullname (with an index suffix if there are
+   several). Point a cert's `spec.secretName` at the HTTPProxy/Ingress TLS secret
+   (which defaults to `<release>-tls`) to wire the two together. When defining more
+   than one certificate, set an explicit `name` on each — the `<fullname>-<index>`
+   fallback is position-sensitive, so reordering the list would rename (and
+   therefore reissue) a Certificate.
 
-The `<release>-tls` default lets a single wildcard `Certificate` back multiple
-releases (e.g. production plus review apps) that reuse the same Secret. When a
-cert is issued out-of-band, leave `certManager.certificate.enabled` false and
-just set the `tls.secretName` on the HTTPProxy/Ingress.
+Using `<release>-tls` as the shared secret lets a single wildcard `Certificate`
+back multiple releases (e.g. production plus review apps) that reuse the same
+Secret. When a cert is issued out-of-band, leave `certificates` empty and just
+set `tls.secretName` on the HTTPProxy/Ingress.

--- a/README.md
+++ b/README.md
@@ -29,7 +29,9 @@ controllers to already be installed in the cluster.
 2. **`contour.httpProxy`** — set `enabled: true` and a `fqdn`. By default a
    single route sends `/` to the Service; override `routes` for custom routing.
    With `tls.enabled: true`, Contour terminates TLS using `tls.secretName`
-   (defaults to `<release>-tls`).
+   (defaults to `<release>-tls`). Set `tls.passthrough: true` to forward
+   encrypted traffic to the backend instead — Contour then routes at L4, so the
+   chart emits a default `tcpproxy` to the Service (override via `tcpproxy`).
 3. **`certificates`** — a list of cert-manager Certificates. Each entry passes its
    `spec` through to the resource as-is (any cert-manager field is supported), and
    `name` defaults to the chart fullname (with an index suffix if there are

--- a/README.md
+++ b/README.md
@@ -47,3 +47,10 @@ Using `<release>-tls` as the shared secret lets a single wildcard `Certificate`
 back multiple releases (e.g. production plus review apps) that reuse the same
 Secret. When a cert is issued out-of-band, leave `certificates` empty and just
 set `tls.secretName` on the HTTPProxy/Ingress.
+
+**Adopting an existing Certificate:** if a `Certificate` of the same name was
+previously created outside Helm (e.g. via `kubectl apply`), `helm upgrade` fails
+with an ownership error. Either delete it first (the TLS Secret survives, so
+there's no reissue) or annotate/label it (`meta.helm.sh/release-name`,
+`meta.helm.sh/release-namespace`, `app.kubernetes.io/managed-by=Helm`) so Helm
+adopts it in place.

--- a/README.md
+++ b/README.md
@@ -15,3 +15,28 @@ To expose `/metrics` for Prometheus Operator scrapes, wire **container port → 
 3. **`serviceMonitor`** — set `enabled: true`. `endpointPort` defaults to `metrics` and must match the **Service** port name (not the container port number).
 
 If the target cluster does not install `monitoring.coreos.com/v1` ServiceMonitors, leave `serviceMonitor.enabled` false and scrape via static config or another mechanism.
+
+## Contour HTTPProxy + cert-manager TLS (`charts/generic`)
+
+For clusters that route with [Contour](https://projectcontour.io/) and issue TLS
+with [cert-manager](https://cert-manager.io/), the chart can render a
+`projectcontour.io/v1` `HTTPProxy` and a `cert-manager.io/v1` `Certificate`
+instead of (or alongside) a plain Ingress. Both require the respective CRDs and
+controllers to already be installed in the cluster.
+
+1. **`service.enabled: true`** — the HTTPProxy routes to the chart's Service on
+   `service.port`, so a Service must exist.
+2. **`contour.httpProxy`** — set `enabled: true` and a `fqdn`. By default a
+   single route sends `/` to the Service; override `routes` for custom routing.
+   With `tls.enabled: true`, Contour terminates TLS using `tls.secretName`
+   (defaults to `<release>-tls`).
+3. **`certManager.certificate`** — a cert-manager Certificate. Set `enabled: true`,
+   provide `dnsNames`, and point `issuerRef.name` at a configured
+   `Issuer`/`ClusterIssuer`. cert-manager writes the issued cert/key into
+   `secretName` (defaults to `<release>-tls`), which matches the HTTPProxy/Ingress
+   TLS default so the two line up.
+
+The `<release>-tls` default lets a single wildcard `Certificate` back multiple
+releases (e.g. production plus review apps) that reuse the same Secret. When a
+cert is issued out-of-band, leave `certManager.certificate.enabled` false and
+just set the `tls.secretName` on the HTTPProxy/Ingress.

--- a/charts/generic/Chart.yaml
+++ b/charts/generic/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: generic
 description: A generic helm chart that handles a bunch of common application deploy cases
 type: application
-version: 1.33.0
+version: 1.34.0

--- a/charts/generic/templates/certificate.yaml
+++ b/charts/generic/templates/certificate.yaml
@@ -1,44 +1,33 @@
-{{- if .Values.certManager.certificate.enabled -}}
-{{- $cert := .Values.certManager.certificate -}}
-{{- if not $cert.dnsNames }}
-{{- fail "certManager.certificate.enabled is true but certManager.certificate.dnsNames is empty. Provide at least one DNS name for the certificate to request." }}
+{{- if .Values.certificates }}
+{{- $fullName := include "generic.fullname" . -}}
+{{- $count := len .Values.certificates -}}
+{{- range $i, $cert := .Values.certificates }}
+{{- $name := $cert.name }}
+{{- if not $name }}
+{{- if eq $count 1 }}
+{{- $name = $fullName }}
+{{- else }}
+{{- $name = printf "%s-%d" $fullName $i }}
 {{- end }}
-{{- if not $cert.issuerRef.name }}
-{{- fail "certManager.certificate.enabled is true but certManager.certificate.issuerRef.name is not set. Provide the (Cluster)Issuer that should sign this certificate." }}
 {{- end }}
+{{- if not $cert.spec }}
+{{- fail (printf "certificates[%d].spec is required" $i) }}
+{{- end }}
+---
 apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
-  name: {{ $cert.name | default (include "generic.fullname" .) }}
+  name: {{ $name }}
   labels:
-    {{- include "generic.labels" . | nindent 4 }}
+    {{- include "generic.labels" $ | nindent 4 }}
+    {{- with $cert.additionalLabels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
   {{- with $cert.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
-  secretName: {{ $cert.secretName | default (printf "%s-tls" .Release.Name) }}
-  {{- with $cert.commonName }}
-  commonName: {{ . | quote }}
-  {{- end }}
-  {{- with $cert.duration }}
-  duration: {{ . }}
-  {{- end }}
-  {{- with $cert.renewBefore }}
-  renewBefore: {{ . }}
-  {{- end }}
-  dnsNames:
-    {{- toYaml $cert.dnsNames | nindent 4 }}
-  {{- with $cert.privateKey }}
-  privateKey:
-    {{- toYaml . | nindent 4 }}
-  {{- end }}
-  {{- with $cert.usages }}
-  usages:
-    {{- toYaml . | nindent 4 }}
-  {{- end }}
-  issuerRef:
-    name: {{ $cert.issuerRef.name }}
-    kind: {{ $cert.issuerRef.kind | default "ClusterIssuer" }}
-    group: {{ $cert.issuerRef.group | default "cert-manager.io" }}
+  {{- toYaml $cert.spec | nindent 2 }}
+{{- end }}
 {{- end }}

--- a/charts/generic/templates/certificate.yaml
+++ b/charts/generic/templates/certificate.yaml
@@ -1,0 +1,44 @@
+{{- if .Values.certManager.certificate.enabled -}}
+{{- $cert := .Values.certManager.certificate -}}
+{{- if not $cert.dnsNames }}
+{{- fail "certManager.certificate.enabled is true but certManager.certificate.dnsNames is empty. Provide at least one DNS name for the certificate to request." }}
+{{- end }}
+{{- if not $cert.issuerRef.name }}
+{{- fail "certManager.certificate.enabled is true but certManager.certificate.issuerRef.name is not set. Provide the (Cluster)Issuer that should sign this certificate." }}
+{{- end }}
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: {{ $cert.name | default (include "generic.fullname" .) }}
+  labels:
+    {{- include "generic.labels" . | nindent 4 }}
+  {{- with $cert.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  secretName: {{ $cert.secretName | default (printf "%s-tls" .Release.Name) }}
+  {{- with $cert.commonName }}
+  commonName: {{ . | quote }}
+  {{- end }}
+  {{- with $cert.duration }}
+  duration: {{ . }}
+  {{- end }}
+  {{- with $cert.renewBefore }}
+  renewBefore: {{ . }}
+  {{- end }}
+  dnsNames:
+    {{- toYaml $cert.dnsNames | nindent 4 }}
+  {{- with $cert.privateKey }}
+  privateKey:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with $cert.usages }}
+  usages:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  issuerRef:
+    name: {{ $cert.issuerRef.name }}
+    kind: {{ $cert.issuerRef.kind | default "ClusterIssuer" }}
+    group: {{ $cert.issuerRef.group | default "cert-manager.io" }}
+{{- end }}

--- a/charts/generic/templates/httpproxy.yaml
+++ b/charts/generic/templates/httpproxy.yaml
@@ -2,11 +2,12 @@
 {{- $fullName := include "generic.fullname" . -}}
 {{- $svcPort := .Values.service.port -}}
 {{- $httpProxy := .Values.contour.httpProxy -}}
+{{- $passthrough := and $httpProxy.tls.enabled $httpProxy.tls.passthrough -}}
 {{- if not $httpProxy.fqdn }}
 {{- fail "contour.httpProxy.enabled is true but contour.httpProxy.fqdn is empty. Provide the fully qualified domain name the HTTPProxy should answer for." }}
 {{- end }}
-{{- if and (not $httpProxy.routes) (not .Values.service.enabled) }}
-{{- fail "contour.httpProxy.enabled is true and relies on the default route to the chart Service, but service.enabled is false. Set service.enabled=true, or provide contour.httpProxy.routes that reference existing services." }}
+{{- if and (not $httpProxy.routes) (not $httpProxy.tcpproxy) (not .Values.service.enabled) }}
+{{- fail "contour.httpProxy.enabled is true and relies on the default route to the chart Service, but service.enabled is false. Set service.enabled=true, or provide contour.httpProxy.routes/tcpproxy that reference existing services." }}
 {{- end }}
 apiVersion: projectcontour.io/v1
 kind: HTTPProxy
@@ -36,10 +37,20 @@ spec:
   includes:
     {{- toYaml . | nindent 4 }}
   {{- end }}
-  routes:
   {{- if $httpProxy.routes }}
+  routes:
     {{- toYaml $httpProxy.routes | nindent 4 }}
+  {{- else if $httpProxy.tcpproxy }}
+  tcpproxy:
+    {{- toYaml $httpProxy.tcpproxy | nindent 4 }}
+  {{- else if $passthrough }}
+  {{- /* TLS passthrough terminates at the backend, so Contour routes at L4 via tcpproxy (not HTTP routes/services). */}}
+  tcpproxy:
+    services:
+      - name: {{ $fullName }}
+        port: {{ $svcPort }}
   {{- else }}
+  routes:
     - conditions:
         - prefix: /
       services:

--- a/charts/generic/templates/httpproxy.yaml
+++ b/charts/generic/templates/httpproxy.yaml
@@ -1,0 +1,49 @@
+{{- if .Values.contour.httpProxy.enabled -}}
+{{- $fullName := include "generic.fullname" . -}}
+{{- $svcPort := .Values.service.port -}}
+{{- $httpProxy := .Values.contour.httpProxy -}}
+{{- if not $httpProxy.fqdn }}
+{{- fail "contour.httpProxy.enabled is true but contour.httpProxy.fqdn is empty. Provide the fully qualified domain name the HTTPProxy should answer for." }}
+{{- end }}
+{{- if and (not $httpProxy.routes) (not .Values.service.enabled) }}
+{{- fail "contour.httpProxy.enabled is true and relies on the default route to the chart Service, but service.enabled is false. Set service.enabled=true, or provide contour.httpProxy.routes that reference existing services." }}
+{{- end }}
+apiVersion: projectcontour.io/v1
+kind: HTTPProxy
+metadata:
+  name: {{ $fullName }}
+  labels:
+    {{- include "generic.labels" . | nindent 4 }}
+  {{- with $httpProxy.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  virtualhost:
+    fqdn: {{ $httpProxy.fqdn }}
+    {{- if $httpProxy.tls.enabled }}
+    tls:
+      {{- if $httpProxy.tls.passthrough }}
+      passthrough: true
+      {{- else }}
+      secretName: {{ $httpProxy.tls.secretName | default (printf "%s-tls" .Release.Name) }}
+      {{- with $httpProxy.tls.minimumProtocolVersion }}
+      minimumProtocolVersion: {{ . | quote }}
+      {{- end }}
+      {{- end }}
+    {{- end }}
+  {{- with $httpProxy.includes }}
+  includes:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  routes:
+  {{- if $httpProxy.routes }}
+    {{- toYaml $httpProxy.routes | nindent 4 }}
+  {{- else }}
+    - conditions:
+        - prefix: /
+      services:
+        - name: {{ $fullName }}
+          port: {{ $svcPort }}
+  {{- end }}
+{{- end }}

--- a/charts/generic/test-values-certificates.yaml
+++ b/charts/generic/test-values-certificates.yaml
@@ -1,0 +1,37 @@
+# Test values to verify cert-manager Certificate resources are rendered
+mode: deployment
+replicaCount: 1
+image:
+  repository: nginx
+  tag: latest
+deployment:
+  containerPort: 80
+  containerPortName: http
+certificates:
+  - name: test-cert-primary
+    additionalLabels:
+      cert-tier: primary
+    annotations:
+      cert-manager.io/test: "true"
+    spec:
+      secretName: test-cert-primary-tls
+      commonName: primary.example.com
+      dnsNames:
+        - primary.example.com
+        - www.primary.example.com
+      issuerRef:
+        name: letsencrypt
+        kind: ClusterIssuer
+        group: cert-manager.io
+      duration: 2160h
+      renewBefore: 360h
+      usages:
+        - server auth
+        - client auth
+  - spec:
+      secretName: test-cert-secondary-tls
+      dnsNames:
+        - secondary.example.com
+      issuerRef:
+        name: selfsigned
+        kind: Issuer

--- a/charts/generic/test-values-contour-cert.yaml
+++ b/charts/generic/test-values-contour-cert.yaml
@@ -1,0 +1,33 @@
+# Test values to verify the Contour HTTPProxy and cert-manager Certificate
+# templates render correctly. The HTTPProxy backs the chart Service, and the
+# Certificate issues into the same "<release>-tls" secret the HTTPProxy reuses.
+mode: deployment
+replicaCount: 1
+image:
+  repository: nginx
+  tag: latest
+deployment:
+  containerPort: 80
+  containerPortName: http
+
+service:
+  enabled: true
+  type: ClusterIP
+  port: 80
+
+contour:
+  httpProxy:
+    enabled: true
+    fqdn: chart-example.local
+    tls:
+      enabled: true
+
+certManager:
+  certificate:
+    enabled: true
+    dnsNames:
+      - chart-example.local
+      - "*.chart-example.local"
+    issuerRef:
+      name: letsencrypt-cf
+      kind: ClusterIssuer

--- a/charts/generic/test-values-contour-cert.yaml
+++ b/charts/generic/test-values-contour-cert.yaml
@@ -1,6 +1,6 @@
-# Test values to verify the Contour HTTPProxy and cert-manager Certificate
-# templates render correctly. The HTTPProxy backs the chart Service, and the
-# Certificate issues into the same "<release>-tls" secret the HTTPProxy reuses.
+# Test values to verify the Contour HTTPProxy and a cert-manager Certificate
+# render together and line up: the HTTPProxy terminates TLS with the default
+# "<release>-tls" secret, and the Certificate issues into that same secret.
 mode: deployment
 replicaCount: 1
 image:
@@ -22,12 +22,13 @@ contour:
     tls:
       enabled: true
 
-certManager:
-  certificate:
-    enabled: true
-    dnsNames:
-      - chart-example.local
-      - "*.chart-example.local"
-    issuerRef:
-      name: letsencrypt-cf
-      kind: ClusterIssuer
+certificates:
+  # secretName matches the HTTPProxy default "<release>-tls" (release "test").
+  - spec:
+      secretName: test-tls
+      dnsNames:
+        - chart-example.local
+        - "*.chart-example.local"
+      issuerRef:
+        name: letsencrypt-cf
+        kind: ClusterIssuer

--- a/charts/generic/values.yaml
+++ b/charts/generic/values.yaml
@@ -216,15 +216,20 @@ contour:
       # secretName: ""
       # Terminate TLS at Contour (default) or pass encrypted traffic straight
       # through to the backend. When passthrough is true, secretName is ignored
-      # and routes must use tcpproxy instead of services.
+      # and Contour routes at L4: the chart emits a default "tcpproxy" to the
+      # Service (not HTTP "routes"). Override with tcpproxy below if needed.
       passthrough: false
       # minimumProtocolVersion: "1.2"
     # Extra HTTPProxy "includes" (delegated routing), passed through as-is.
     # includes: []
     # By default a single route sends all traffic ("/") to the chart's Service
-    # on service.port. Provide routes here to override with your own, passed to
-    # the HTTPProxy as-is. See https://projectcontour.io/docs/main/config/api/
+    # on service.port (or, when tls.passthrough is true, a tcpproxy to it).
+    # Provide routes here to override with your own, passed to the HTTPProxy
+    # as-is. See https://projectcontour.io/docs/main/config/api/
     # routes: []
+    # L4 TCP proxying, passed through as-is. Used for TLS passthrough (and takes
+    # precedence over the generated default). Mutually exclusive with routes.
+    # tcpproxy: {}
 
 # cert-manager Certificate resources (cert-manager.io/v1).
 # Each entry creates one Certificate. The full Certificate spec is passed through

--- a/charts/generic/values.yaml
+++ b/charts/generic/values.yaml
@@ -200,6 +200,62 @@ gatewayAPI:
     # See the HTTPRoute documentation for configuration details: https://gateway-api.sigs.k8s.io/api-types/httproute/
     # rules: {}
 
+# Contour-specific routing. Assumes the Contour ingress controller and its
+# projectcontour.io/v1 HTTPProxy CRD are already installed in the cluster.
+contour:
+  httpProxy:
+    enabled: false
+    annotations: {}
+    # The fully qualified domain name that this proxy answers for.
+    fqdn: chart-example.local
+    tls:
+      enabled: true
+      # Reuse a pre-existing TLS Secret. Defaults to "<release>-tls", which
+      # matches the Secret produced by certManager.certificate below (or the
+      # ingress TLS default) so the two features line up out of the box.
+      # secretName: ""
+      # Terminate TLS at Contour (default) or pass encrypted traffic straight
+      # through to the backend. When passthrough is true, secretName is ignored
+      # and routes must use tcpproxy instead of services.
+      passthrough: false
+      # minimumProtocolVersion: "1.2"
+    # Extra HTTPProxy "includes" (delegated routing), passed through as-is.
+    # includes: []
+    # By default a single route sends all traffic ("/") to the chart's Service
+    # on service.port. Provide routes here to override with your own, passed to
+    # the HTTPProxy as-is. See https://projectcontour.io/docs/main/config/api/
+    # routes: []
+
+# cert-manager integration. Assumes cert-manager and its cert-manager.io/v1
+# Certificate CRD are already installed, along with the referenced Issuer.
+certManager:
+  certificate:
+    enabled: false
+    annotations: {}
+    # Name of the Certificate resource. Defaults to the chart fullname.
+    # name: ""
+    # Secret where cert-manager stores the issued cert/key. Defaults to
+    # "<release>-tls" so it can be consumed directly by the ingress/HTTPProxy
+    # TLS defaults above.
+    # secretName: ""
+    # DNS names the certificate should be valid for (required when enabled).
+    dnsNames: []
+    #  - chart-example.local
+    #  - "*.chart-example.local"
+    # commonName: chart-example.local
+    # duration: 2160h
+    # renewBefore: 360h
+    # privateKey:
+    #   algorithm: ECDSA
+    #   size: 256
+    # usages:
+    #   - server auth
+    # The Issuer/ClusterIssuer that signs this certificate (name required).
+    issuerRef:
+      name: ""
+      kind: ClusterIssuer
+      group: cert-manager.io
+
 networkPolicy:
   enabled: false
   policyTypes: []

--- a/charts/generic/values.yaml
+++ b/charts/generic/values.yaml
@@ -210,9 +210,9 @@ contour:
     fqdn: chart-example.local
     tls:
       enabled: true
-      # Reuse a pre-existing TLS Secret. Defaults to "<release>-tls", which
-      # matches the Secret produced by certManager.certificate below (or the
-      # ingress TLS default) so the two features line up out of the box.
+      # Reuse a pre-existing TLS Secret. Defaults to "<release>-tls" (the same
+      # default the ingress TLS block uses). Point a cert-manager Certificate
+      # (see "certificates" below) at this secretName to have it auto-populated.
       # secretName: ""
       # Terminate TLS at Contour (default) or pass encrypted traffic straight
       # through to the backend. When passthrough is true, secretName is ignored
@@ -226,35 +226,37 @@ contour:
     # the HTTPProxy as-is. See https://projectcontour.io/docs/main/config/api/
     # routes: []
 
-# cert-manager integration. Assumes cert-manager and its cert-manager.io/v1
-# Certificate CRD are already installed, along with the referenced Issuer.
-certManager:
-  certificate:
-    enabled: false
-    annotations: {}
-    # Name of the Certificate resource. Defaults to the chart fullname.
-    # name: ""
-    # Secret where cert-manager stores the issued cert/key. Defaults to
-    # "<release>-tls" so it can be consumed directly by the ingress/HTTPProxy
-    # TLS defaults above.
-    # secretName: ""
-    # DNS names the certificate should be valid for (required when enabled).
-    dnsNames: []
-    #  - chart-example.local
-    #  - "*.chart-example.local"
-    # commonName: chart-example.local
-    # duration: 2160h
-    # renewBefore: 360h
-    # privateKey:
-    #   algorithm: ECDSA
-    #   size: 256
-    # usages:
-    #   - server auth
-    # The Issuer/ClusterIssuer that signs this certificate (name required).
-    issuerRef:
-      name: ""
-      kind: ClusterIssuer
-      group: cert-manager.io
+# cert-manager Certificate resources (cert-manager.io/v1).
+# Each entry creates one Certificate. The full Certificate spec is passed through
+# as-is, so any field supported by cert-manager can be set here.
+# See: https://cert-manager.io/docs/usage/certificate/
+#
+# NOTE: when defining more than one certificate, set an explicit "name" on each.
+# Unnamed entries fall back to "<fullname>-<index>", which is position-sensitive:
+# reordering the list would rename the Certificate, causing cert-manager to prune
+# and reissue it. An explicit name keeps the resource identity stable.
+certificates: []
+#  - # Optional, but recommended (required for stable names when >1 cert).
+#    # Defaults to the chart fullname (with an index suffix if multiple).
+#    name: ""
+#    annotations: {}
+#    additionalLabels: {}
+#    # The Certificate spec — passed through to the resource as-is.
+#    spec:
+#      secretName: chart-example-tls
+#      commonName: chart-example.local
+#      dnsNames:
+#        - chart-example.local
+#        - www.chart-example.local
+#      issuerRef:
+#        name: letsencrypt
+#        kind: ClusterIssuer
+#        group: cert-manager.io
+#      # duration: 2160h
+#      # renewBefore: 360h
+#      # usages:
+#      #   - server auth
+#      #   - client auth
 
 networkPolicy:
   enabled: false


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes affect TLS and edge routing when enabled; misconfigured Certificate names or list reordering can trigger cert reissue, though features are opt-in with template validation.
> 
> **Overview**
> Adds optional **Contour `HTTPProxy`** and **cert-manager `Certificate`** rendering to `charts/generic` (v1.34.0), both **off by default**.
> 
> **`contour.httpProxy`** (when enabled) creates a `projectcontour.io/v1` HTTPProxy with required `fqdn`, optional TLS (default secret `<release>-tls`, matching Ingress), custom `routes`/`includes`/`tcpproxy`, and **TLS passthrough** via auto-generated `tcpproxy` instead of HTTP routes. Template **`fail`**s on empty `fqdn` or default routing when `service.enabled` is false (custom routes/tcpproxy can skip the Service).
> 
> **`certificates`** emits one or more `cert-manager.io/v1` Certificates from a list with passthrough `spec`, optional labels/annotations, and naming defaults (`fullname` or `fullname-<index>`); **`fail`**s if `spec` is missing.
> 
> README documents wiring HTTPProxy TLS to Certificate `secretName`, shared `<release>-tls`, and adopting pre-existing Certificates. CI adds `helm template` checks for happy paths, default-disabled behavior, and validation errors.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0c8ea318b324d1c859cf9fd36c62a14ab77c0159. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->