### PR TITLE
Add namespace-scoped Role and RoleBinding support to generic chart

### DIFF
--- a/charts/generic/Chart.yaml
+++ b/charts/generic/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: generic
 description: A generic helm chart that handles a bunch of common application deploy cases
 type: application
-version: 1.32.0
+version: 1.33.0

--- a/charts/generic/templates/role.yaml
+++ b/charts/generic/templates/role.yaml
@@ -1,0 +1,12 @@
+{{- if and .Values.serviceAccount.create (gt (len .Values.serviceAccount.roleRules) 0) -}}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ include "generic.fullname" . }}
+  labels:
+    {{- include "generic.labels" . | nindent 4 }}
+{{- with .Values.serviceAccount.roleRules }}
+rules:
+  {{- toYaml . | nindent 2 }}
+{{- end }}
+{{- end }}

--- a/charts/generic/templates/rolebinding.yaml
+++ b/charts/generic/templates/rolebinding.yaml
@@ -1,0 +1,16 @@
+{{- if and .Values.serviceAccount.create (gt (len .Values.serviceAccount.roleRules) 0) -}}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ include "generic.fullname" . }}
+  labels:
+    {{- include "generic.labels" . | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ include "generic.fullname" . }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "generic.serviceAccountName" . }}
+    namespace: {{ .Release.Namespace }}
+{{- end }}

--- a/charts/generic/values.yaml
+++ b/charts/generic/values.yaml
@@ -61,6 +61,7 @@ serviceAccount:
   # If not set and create is true, a name is generated using the fullname template
   name: ""
   clusterRoleRules: []
+  roleRules: []
 
 # Specifies whether to recreate Pods on a redeploy if nothing else about the underlying Pods changed.
 # This is useful for Deployments that deploy an unchanging image tag like :latest,


### PR DESCRIPTION
## Summary

- Add `serviceAccount.roleRules` to the generic chart, mirroring the existing `clusterRoleRules` but creating a namespace-scoped Role + RoleBinding instead of ClusterRole + ClusterRoleBinding
- Enables workloads like leader election sidecars to get namespace-scoped RBAC (leases, pods) via helm values instead of requiring a separate kubectl-applied manifest
- Bumps chart version to 1.33.0

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces Kubernetes RBAC objects driven by Helm values; misconfigured rules could grant excessive permissions within a namespace, though scope stays namespace-local unlike ClusterRole.
> 
> **Overview**
> Adds **`serviceAccount.roleRules`** to the generic Helm chart so releases can declare namespace-scoped RBAC in values, parallel to the existing **`clusterRoleRules`** flow.
> 
> When the service account is created and `roleRules` is non-empty, the chart now renders a **Role** and **RoleBinding** that bind those rules to the release’s service account in the release namespace. Chart version is bumped to **1.33.0**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0bf5665797182b4208655a6be0047cb108dd58a5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->