### PR TITLE
Add additionalIngresses feature

### DIFF
--- a/.github/workflows/install-charts.yaml
+++ b/.github/workflows/install-charts.yaml
@@ -493,10 +493,10 @@ jobs:
         run: |
           helm template test ./charts/generic -f ./charts/generic/test-values-additional-ingresses.yaml > /tmp/additional-ingress-output.yaml
           INGRESS_COUNT=$(grep -c "kind: Ingress" /tmp/additional-ingress-output.yaml || echo "0")
-          if [ "$INGRESS_COUNT" -eq 2 ]; then
-            echo "✓ Correctly created 2 additional Ingresses"
+          if [ "$INGRESS_COUNT" -eq 3 ]; then
+            echo "✓ Correctly created 3 additional Ingresses"
           else
-            echo "✗ Expected 2 Ingresses, found $INGRESS_COUNT"
+            echo "✗ Expected 3 Ingresses, found $INGRESS_COUNT"
             cat /tmp/additional-ingress-output.yaml
             exit 1
           fi
@@ -522,11 +522,21 @@ jobs:
             cat /tmp/additional-ingress-output.yaml
             exit 1
           fi
-          # TLS secret name from the named entry must be rendered (rendered quoted)
+          # TLS secret name must render even though tlsEnabled/tlsSecretEnabled are
+          # omitted (they must default to true, matching the primary ingress). Rendered quoted.
           if grep -q 'secretName: "test-ingress-primary-tls"' /tmp/additional-ingress-output.yaml; then
-            echo "✓ TLS secretName rendered correctly"
+            echo "✓ TLS secretName renders by default (tlsSecretEnabled defaults to true)"
           else
             echo "✗ TLS secretName not found"
+            cat /tmp/additional-ingress-output.yaml
+            exit 1
+          fi
+          # A defaultBackend-only entry must render an Ingress even without hosts
+          if grep -q "name: test-ingress-default-backend" /tmp/additional-ingress-output.yaml \
+            && grep -q "defaultBackend:" /tmp/additional-ingress-output.yaml; then
+            echo "✓ defaultBackend-only Ingress renders without hosts"
+          else
+            echo "✗ defaultBackend-only Ingress not rendered as expected"
             cat /tmp/additional-ingress-output.yaml
             exit 1
           fi

--- a/.github/workflows/install-charts.yaml
+++ b/.github/workflows/install-charts.yaml
@@ -479,6 +479,58 @@ jobs:
             exit 1
           fi
 
+      - name: Test additionalIngresses - verify no Ingress created by default
+        run: |
+          helm template test ./charts/generic -f ./charts/generic/values.yaml > /tmp/additional-ingress-default.yaml
+          if grep -q "kind: Ingress" /tmp/additional-ingress-default.yaml; then
+            echo "✗ Unexpected Ingress found in default values output"
+            exit 1
+          else
+            echo "✓ No Ingress created by default (correct)"
+          fi
+
+      - name: Test additionalIngresses - verify Ingresses can be created
+        run: |
+          helm template test ./charts/generic -f ./charts/generic/test-values-additional-ingresses.yaml > /tmp/additional-ingress-output.yaml
+          INGRESS_COUNT=$(grep -c "kind: Ingress" /tmp/additional-ingress-output.yaml || echo "0")
+          if [ "$INGRESS_COUNT" -eq 2 ]; then
+            echo "✓ Correctly created 2 additional Ingresses"
+          else
+            echo "✗ Expected 2 Ingresses, found $INGRESS_COUNT"
+            cat /tmp/additional-ingress-output.yaml
+            exit 1
+          fi
+          if grep -q "name: test-ingress-primary" /tmp/additional-ingress-output.yaml; then
+            echo "✓ Named Ingress has correct name"
+          else
+            echo "✗ Named Ingress not found"
+            exit 1
+          fi
+          # Unnamed second entry must fall back to an indexed fullname
+          if grep -q "name: test-generic-2" /tmp/additional-ingress-output.yaml; then
+            echo "✓ Unnamed Ingress defaults to indexed fullname"
+          else
+            echo "✗ Unnamed Ingress name not defaulted as expected"
+            cat /tmp/additional-ingress-output.yaml
+            exit 1
+          fi
+          # Custom serviceName/servicePort must be honored in the backend
+          if grep -q "name: other-svc" /tmp/additional-ingress-output.yaml; then
+            echo "✓ Custom backend serviceName honored"
+          else
+            echo "✗ Custom backend serviceName not found"
+            cat /tmp/additional-ingress-output.yaml
+            exit 1
+          fi
+          # TLS secret name from the named entry must be rendered
+          if grep -q "secretName: test-ingress-primary-tls" /tmp/additional-ingress-output.yaml; then
+            echo "✓ TLS secretName rendered correctly"
+          else
+            echo "✗ TLS secretName not found"
+            cat /tmp/additional-ingress-output.yaml
+            exit 1
+          fi
+
       - name: Install generic-stateful chart
         uses: Chia-Network/actions/helm/deploy@main
         with:

--- a/.github/workflows/install-charts.yaml
+++ b/.github/workflows/install-charts.yaml
@@ -522,8 +522,8 @@ jobs:
             cat /tmp/additional-ingress-output.yaml
             exit 1
           fi
-          # TLS secret name from the named entry must be rendered
-          if grep -q "secretName: test-ingress-primary-tls" /tmp/additional-ingress-output.yaml; then
+          # TLS secret name from the named entry must be rendered (rendered quoted)
+          if grep -q 'secretName: "test-ingress-primary-tls"' /tmp/additional-ingress-output.yaml; then
             echo "✓ TLS secretName rendered correctly"
           else
             echo "✗ TLS secretName not found"

--- a/charts/generic/Chart.yaml
+++ b/charts/generic/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: generic
 description: A generic helm chart that handles a bunch of common application deploy cases
 type: application
-version: 1.34.0
+version: 1.35.0

--- a/charts/generic/templates/additionalIngresses.yaml
+++ b/charts/generic/templates/additionalIngresses.yaml
@@ -2,12 +2,21 @@
 {{- $fullName := include "generic.fullname" . -}}
 {{- $svcPort := .Values.service.port -}}
 {{- range $i, $ing := $.Values.additionalIngresses }}
-{{- if .hosts }}
+{{- $ruleType := (default "rules" $ing.ruleType) }}
+{{- if or $ing.hosts (eq $ruleType "defaultBackend") }}
 {{- $name := (default (printf "%s-%d" $fullName (add $i 1)) $ing.name) }}
 {{- $ingSvcName := (default $fullName $ing.serviceName) }}
 {{- $ingSvcPort := (default $svcPort $ing.servicePort) }}
-{{- $ruleType := (default "rules" $ing.ruleType) }}
 {{- $annotations := (default (dict) $ing.annotations) }}
+{{/* List entries don't inherit values.yaml defaults, so mirror the primary ingress opt-out defaults (true) while honoring an explicit false */}}
+{{- $tlsEnabled := true }}
+{{- if hasKey $ing "tlsEnabled" }}
+{{- $tlsEnabled = $ing.tlsEnabled }}
+{{- end }}
+{{- $tlsSecretEnabled := true }}
+{{- if hasKey $ing "tlsSecretEnabled" }}
+{{- $tlsSecretEnabled = $ing.tlsSecretEnabled }}
+{{- end }}
 {{- if and $ing.className (not (semverCompare ">=1.18-0" $.Capabilities.KubeVersion.GitVersion)) }}
 {{- if not (hasKey $annotations "kubernetes.io/ingress.class") }}
 {{- $_ := set $annotations "kubernetes.io/ingress.class" $ing.className }}
@@ -37,13 +46,13 @@ spec:
   {{- if and $ing.className (semverCompare ">=1.18-0" $.Capabilities.KubeVersion.GitVersion) }}
   ingressClassName: {{ $ing.className }}
   {{- end }}
-  {{- if $ing.tlsEnabled }}
+  {{- if $tlsEnabled }}
   tls:
     - hosts:
       {{- range $ing.hosts }}
         - {{ .host | quote }}
       {{- end }}
-      {{- if $ing.tlsSecretEnabled }}
+      {{- if $tlsSecretEnabled }}
       secretName: "{{ $ing.tlsSecretName | default (printf "%s-tls" $name) }}"
       {{- end }}
   {{- end }}

--- a/charts/generic/templates/additionalIngresses.yaml
+++ b/charts/generic/templates/additionalIngresses.yaml
@@ -1,0 +1,82 @@
+{{- if .Values.additionalIngresses -}}
+{{- $fullName := include "generic.fullname" . -}}
+{{- $svcPort := .Values.service.port -}}
+{{- range $i, $ing := $.Values.additionalIngresses }}
+{{- if .hosts }}
+{{- $name := (default (printf "%s-%d" $fullName (add $i 1)) $ing.name) }}
+{{- $ingSvcName := (default $fullName $ing.serviceName) }}
+{{- $ingSvcPort := (default $svcPort $ing.servicePort) }}
+{{- $ruleType := (default "rules" $ing.ruleType) }}
+{{- $annotations := (default (dict) $ing.annotations) }}
+{{- if and $ing.className (not (semverCompare ">=1.18-0" $.Capabilities.KubeVersion.GitVersion)) }}
+{{- if not (hasKey $annotations "kubernetes.io/ingress.class") }}
+{{- $_ := set $annotations "kubernetes.io/ingress.class" $ing.className }}
+{{- end }}
+{{- end }}
+---
+{{- if semverCompare ">=1.19-0" $.Capabilities.KubeVersion.GitVersion }}
+apiVersion: networking.k8s.io/v1
+{{- else if semverCompare ">=1.14-0" $.Capabilities.KubeVersion.GitVersion }}
+apiVersion: networking.k8s.io/v1beta1
+{{- else }}
+apiVersion: extensions/v1beta1
+{{- end }}
+kind: Ingress
+metadata:
+  name: {{ $name }}
+  labels:
+    {{- include "generic.labels" $ | nindent 4 }}
+    {{- with $ing.additionalLabels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- with $annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if and $ing.className (semverCompare ">=1.18-0" $.Capabilities.KubeVersion.GitVersion) }}
+  ingressClassName: {{ $ing.className }}
+  {{- end }}
+  {{- if $ing.tlsEnabled }}
+  tls:
+    - hosts:
+      {{- range $ing.hosts }}
+        - {{ .host | quote }}
+      {{- end }}
+      {{- if $ing.tlsSecretEnabled }}
+      secretName: "{{ $ing.tlsSecretName | default (printf "%s-tls" $name) }}"
+      {{- end }}
+  {{- end }}
+  {{- if eq $ruleType "rules" }}
+  rules:
+    {{- range $ing.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+          {{- range .paths }}
+          - path: {{ .path }}
+            {{- if and .pathType (semverCompare ">=1.18-0" $.Capabilities.KubeVersion.GitVersion) }}
+            pathType: {{ .pathType }}
+            {{- end }}
+            backend:
+              {{- if semverCompare ">=1.19-0" $.Capabilities.KubeVersion.GitVersion }}
+              service:
+                name: {{ $ingSvcName }}
+                port:
+                  number: {{ .port | default $ingSvcPort }}
+              {{- else }}
+              serviceName: {{ $ingSvcName }}
+              servicePort: {{ .port | default $ingSvcPort }}
+              {{- end }}
+          {{- end }}
+    {{- end }}
+  {{- else if eq $ruleType "defaultBackend" }}
+  defaultBackend:
+    service:
+      name: {{ $ingSvcName }}
+      port:
+        number: {{ $ingSvcPort }}
+  {{- end }}
+{{- end }}
+{{- end }}
+{{- end }}

--- a/charts/generic/test-values-additional-ingresses.yaml
+++ b/charts/generic/test-values-additional-ingresses.yaml
@@ -22,9 +22,9 @@ additionalIngresses:
         paths:
           - path: /
             pathType: Prefix
-    tlsEnabled: true
+    # tlsEnabled/tlsSecretEnabled omitted on purpose: they must default to true
+    # (matching the primary ingress) so the secretName still renders.
     tlsSecretName: test-ingress-primary-tls
-    tlsSecretEnabled: true
     ruleType: rules
   # Unnamed entry: falls back to an indexed fullname. Routes to a different Service.
   - className: nginx
@@ -38,3 +38,8 @@ additionalIngresses:
             port: 9090
     tlsEnabled: false
     ruleType: rules
+  # defaultBackend-only catch-all: valid with no hosts, must still render an Ingress.
+  - name: test-ingress-default-backend
+    className: nginx
+    tlsEnabled: false
+    ruleType: defaultBackend

--- a/charts/generic/test-values-additional-ingresses.yaml
+++ b/charts/generic/test-values-additional-ingresses.yaml
@@ -1,0 +1,40 @@
+# Test values to verify additional Ingress resources are rendered
+mode: deployment
+replicaCount: 1
+image:
+  repository: nginx
+  tag: latest
+deployment:
+  containerPort: 80
+  containerPortName: http
+service:
+  enabled: true
+  port: 80
+additionalIngresses:
+  - name: test-ingress-primary
+    className: nginx
+    additionalLabels:
+      ingress-tier: primary
+    annotations:
+      kubernetes.io/tls-acme: "true"
+    hosts:
+      - host: primary.example.com
+        paths:
+          - path: /
+            pathType: Prefix
+    tlsEnabled: true
+    tlsSecretName: test-ingress-primary-tls
+    tlsSecretEnabled: true
+    ruleType: rules
+  # Unnamed entry: falls back to an indexed fullname. Routes to a different Service.
+  - className: nginx
+    serviceName: other-svc
+    servicePort: 8080
+    hosts:
+      - host: secondary.example.com
+        paths:
+          - path: /
+            pathType: Prefix
+            port: 9090
+    tlsEnabled: false
+    ruleType: rules

--- a/charts/generic/values.yaml
+++ b/charts/generic/values.yaml
@@ -194,16 +194,18 @@ additionalIngresses: []
 #    annotations: {}
 #      # kubernetes.io/ingress.class: nginx
 #      # kubernetes.io/tls-acme: "true"
+#    # hosts is optional when ruleType is "defaultBackend"
 #    hosts:
 #      - host: chart-example.local
 #        paths:
 #          - path: /
 #            pathType: Prefix
 #            # port: 8080  # Optional: custom backend port for this path, otherwise uses servicePort
+#    # Defaults to true when omitted (matches the primary ingress). Set to false to disable TLS.
 #    tlsEnabled: true
 #    # Uncomment to use a pre-generated TLS Secret (defaults to "<ingress name>-tls")
 #    # tlsSecretName: ""
-#    # Set to false if TLS is enabled, but you're using an ingress class that doesn't support TLS cert secrets
+#    # Defaults to true when omitted. Set to false if TLS is enabled, but you're using an ingress class that doesn't support TLS cert secrets
 #    tlsSecretEnabled: true
 #    # Switch between different Ingress rule styles. Can be one of "rules", or "defaultBackend"
 #    ruleType: "rules"

--- a/charts/generic/values.yaml
+++ b/charts/generic/values.yaml
@@ -179,6 +179,35 @@ ingress:
   # Switch between different Ingress rule styles. Can be one of "rules", or "defaultBackend"
   ruleType: "rules"
 
+# Sometimes, additional Ingresses are needed alongside the primary one
+# (e.g. a second hostname/class, or routing to a different Service).
+# Each entry mirrors the primary "ingress" block above.
+additionalIngresses: []
+#  - name: ingress-name # If omitted, it will be named like the primary ingress, with an incrementing number
+#    className: ""
+#    # Route to a different Service (defaults to the chart's primary Service)
+#    serviceName: ""
+#    # Default backend port for paths that don't specify their own (defaults to service.port)
+#    servicePort: 80
+#    additionalLabels: {}
+#      # application: my-application
+#    annotations: {}
+#      # kubernetes.io/ingress.class: nginx
+#      # kubernetes.io/tls-acme: "true"
+#    hosts:
+#      - host: chart-example.local
+#        paths:
+#          - path: /
+#            pathType: Prefix
+#            # port: 8080  # Optional: custom backend port for this path, otherwise uses servicePort
+#    tlsEnabled: true
+#    # Uncomment to use a pre-generated TLS Secret (defaults to "<ingress name>-tls")
+#    # tlsSecretName: ""
+#    # Set to false if TLS is enabled, but you're using an ingress class that doesn't support TLS cert secrets
+#    tlsSecretEnabled: true
+#    # Switch between different Ingress rule styles. Can be one of "rules", or "defaultBackend"
+#    ruleType: "rules"
+
 gatewayAPI:
   # This supports the v1 HTTPRoute API schema. It assumes a properly configured GatewayClass and Gateway is already installed and programmed.
   httpRoute:


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Additive Helm templating and CI only; no changes to default installs (`additionalIngresses: []`), with behavior covered by template tests.
> 
> **Overview**
> The **generic** chart (v**1.35.0**) gains an opt-in `additionalIngresses` list so releases can emit extra `Ingress` objects beside the primary `ingress` block—useful for extra hostnames, classes, or backends on another Service.
> 
> Each list item follows the same shape as the main ingress: optional name (default `<fullname>-<index>`), `serviceName` / `servicePort`, labels, annotations, hosts/paths, TLS (`tlsEnabled` / `tlsSecretEnabled` default to **true** when omitted, like the primary ingress), and `ruleType` of `rules` or `defaultBackend` (the latter can render without `hosts`). Templates pick the right Ingress API version and handle pre-1.18 ingress class annotations.
> 
> CI adds `helm template` checks that default values produce no Ingress, and that `test-values-additional-ingresses.yaml` renders three Ingresses with the expected names, backends, TLS secret, and default-backend behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 959213d5737114c4ab829144bc2de49992a66ba9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->